### PR TITLE
Feature/install map

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Install Node Package
+
+Before runs the app, run the following command to install all node packages.
+
+### `npm install`
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-## Install Node Package
+## Install Node Packages
 
 Before runs the app, run the following command to install all node packages.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react": "^17.0.3",
         "@types/react-dom": "^17.0.2",
         "leaflet": "^1.7.1",
+        "nanoid": "^3.1.22",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-leaflet": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^12.20.6",
         "@types/react": "^17.0.3",
         "@types/react-dom": "^17.0.2",
+        "leaflet": "^1.7.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-leaflet": "^3.1.0",
@@ -12540,8 +12541,7 @@
     "node_modules/leaflet": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
-      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
-      "peer": true
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -31089,8 +31089,7 @@
     "leaflet": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
-      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
-      "peer": true
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
     },
     "leven": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,13 @@
         "@types/react-dom": "^17.0.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
+        "react-leaflet": "^3.1.0",
         "react-scripts": "4.0.3",
         "typescript": "^4.2.3",
         "web-vitals": "^1.1.1"
+      },
+      "devDependencies": {
+        "@types/leaflet": "^1.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2331,6 +2335,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-QbleYZTMcgujAEyWGki8Lx6cXQqWkNtQlqf5c7NImlIp8bKW66bFpez/6EVatW7+p9WKBOEOVci/9W7WW70EZg==",
+      "peerDependencies": {
+        "leaflet": "^1.7.1",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1"
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -2920,6 +2934,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
       "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
+      "dev": true
+    },
     "node_modules/@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -2981,6 +3001,15 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.0.tgz",
+      "integrity": "sha512-ltv5jR+VjKSMtoDkxH61Rsbo0zLU7iqyOXpVPkAX4F+79fg2eymC7t0msWsfNaEZO1FGTIQATCCCQe+ijWoicg==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.3",
@@ -12508,6 +12537,12 @@
         "webpack-sources": "^1.1.0"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
+      "peer": true
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15940,6 +15975,19 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+    },
+    "node_modules/react-leaflet": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-3.1.0.tgz",
+      "integrity": "sha512-kdZS8NYbYFPmkQr7zSDR2gkKGFeWvkxqoqcmZEckzHL4d5c85dJ2gbbqhaPDpmWWgaRw9O29uA/77qpKmK4mTQ==",
+      "dependencies": {
+        "@react-leaflet/core": "^1.0.2"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.7.1",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
@@ -23143,6 +23191,12 @@
         }
       }
     },
+    "@react-leaflet/core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-QbleYZTMcgujAEyWGki8Lx6cXQqWkNtQlqf5c7NImlIp8bKW66bFpez/6EVatW7+p9WKBOEOVci/9W7WW70EZg==",
+      "requires": {}
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -23565,6 +23619,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
       "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
     },
+    "@types/geojson": {
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -23626,6 +23686,15 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "@types/leaflet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.0.tgz",
+      "integrity": "sha512-ltv5jR+VjKSMtoDkxH61Rsbo0zLU7iqyOXpVPkAX4F+79fg2eymC7t0msWsfNaEZO1FGTIQATCCCQe+ijWoicg==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -31017,6 +31086,12 @@
         "webpack-sources": "^1.1.0"
       }
     },
+    "leaflet": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
+      "peer": true
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -33765,6 +33840,14 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+    },
+    "react-leaflet": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-3.1.0.tgz",
+      "integrity": "sha512-kdZS8NYbYFPmkQr7zSDR2gkKGFeWvkxqoqcmZEckzHL4d5c85dJ2gbbqhaPDpmWWgaRw9O29uA/77qpKmK4mTQ==",
+      "requires": {
+        "@react-leaflet/core": "^1.0.2"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^12.20.6",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.2",
+    "leaflet": "^1.7.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-leaflet": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^17.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-leaflet": "^3.1.0",
     "react-scripts": "4.0.3",
     "typescript": "^4.2.3",
     "web-vitals": "^1.1.1"
@@ -39,5 +40,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/leaflet": "^1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.2",
     "leaflet": "^1.7.1",
+    "nanoid": "^3.1.22",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-leaflet": "^3.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,16 +24,24 @@ function App() {
   const Markers: any = positions.map((pos: LatLng) => {
     return <Marker position={[pos.lat, pos.lng]} key={nanoid()}/>
   })
+
+  function onClickHandler(){
+    setPositions([]);
+  }
+
   return (
-    <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={true}>
-      <TileLayer
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
-      <ClickLayer positions={positions} setPositions={setPositions}/>
-      {Markers}
-      {polyline === [] ? null : <Polyline pathOptions={limeOptions} positions={polyline} />}
-    </MapContainer>
+    <>
+      <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={true}>
+        <TileLayer
+          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <ClickLayer positions={positions} setPositions={setPositions}/>
+        {Markers}
+        {polyline === [] ? null : <Polyline pathOptions={limeOptions} positions={polyline} />}
+      </MapContainer>
+      <button onClick={onClickHandler}>リセット</button>
+    </>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,22 @@
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
+import 'leaflet/dist/leaflet.css';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
+      <TileLayer
+        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Marker position={[51.505, -0.09]}>
+        <Popup>
+          A pretty CSS3 popup. <br /> Easily customizable.
+        </Popup>
+      </Marker>
+    </MapContainer>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,13 +32,13 @@ function App() {
   return (
     <>
       <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={true}>
+      {Markers}
+        {polyline === [] ? null : <Polyline pathOptions={limeOptions} positions={polyline} />}
         <TileLayer
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <ClickLayer positions={positions} setPositions={setPositions}/>
-        {Markers}
-        {polyline === [] ? null : <Polyline pathOptions={limeOptions} positions={polyline} />}
       </MapContainer>
       <button onClick={onClickHandler}>リセット</button>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import 'leaflet/dist/leaflet.css';
-import { MapContainer, TileLayer, Marker, Popup, useMapEvents, Polyline } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMapEvents, Polyline, useMapEvent } from 'react-leaflet';
+import { LatLng } from 'leaflet';
 
 const polyline: any = [
   [51.505, -0.09],
@@ -11,22 +12,22 @@ const polyline: any = [
 ]
 const limeOptions = { color: 'lime' }
 
-function LocationMarker(){
-  const [position, setPosition]: any = useState(null);
-  const map = useMapEvents({
-    click(){
-      map.locate() //ユーザーの現在地点を取得してlocationfoundイベントを発火させる
-    },
-    locationfound(e: any) {
-      setPosition(e.latlng)
-      map.flyTo(e.latlng, map.getZoom())
-    },
+function MarkerComponent(){
+  const [positions, setPositions]: any = useState([]);
+
+  const map = useMapEvent('click', (e: any)=>{
+    setPositions([...positions, e.latlng]);
   })
-  return position === null ? null : (
-    <Marker position={position}>
-      <Popup>You are here</Popup>
-    </Marker>
-  )
+
+  const Markers = positions.map((pos: LatLng) => {
+    return <Marker position={[pos.lat, pos.lng]}/>
+  })
+  
+  return (
+    <>
+    {Markers}
+    </>
+  );
 }
 
 function App() {
@@ -36,13 +37,8 @@ function App() {
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      <Marker position={[51.505, -0.09]}>
-        <Popup>
-          A pretty CSS3 popup. <br /> Easily customizable.
-        </Popup>
-      </Marker>
-      <LocationMarker />
-      <Polyline pathOptions={limeOptions} positions={polyline} />
+      <MarkerComponent/>
+      {/* <Polyline pathOptions={limeOptions} positions={polyline} /> */}
     </MapContainer>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ function LocationMarker(){
 
 function App() {
   return (
-    <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
+    <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={true}>
       <TileLayer
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,40 +6,33 @@ import { nanoid } from 'nanoid';
 import { MapContainer, TileLayer, Marker, Popup, useMapEvents, Polyline, useMapEvent } from 'react-leaflet';
 import { LatLng } from 'leaflet';
 
-const polyline: any = [
-  [51.505, -0.09],
-  [51.51, -0.1],
-  [51.51, -0.12],
-]
 const limeOptions = { color: 'lime' }
 
-function MarkerComponent(){
-  const [positions, setPositions]: any = useState([]);
-
+function ClickLayer({positions, setPositions}: any){
   const map = useMapEvent('click', (e: any)=>{
     setPositions([...positions, e.latlng]);
   })
-
-  const Markers = positions.map((pos: LatLng) => {
-    return <Marker position={[pos.lat, pos.lng]} key={nanoid()}/>
-  })
   
-  return (
-    <>
-    {Markers}
-    </>
-  );
+  return null;
 }
 
 function App() {
+  const [positions, setPositions] = useState([]);
+
+  const polyline: any = positions.map((pos: LatLng) => [pos.lat, pos.lng])
+
+  const Markers: any = positions.map((pos: LatLng) => {
+    return <Marker position={[pos.lat, pos.lng]} key={nanoid()}/>
+  })
   return (
     <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={true}>
       <TileLayer
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      <MarkerComponent/>
-      {/* <Polyline pathOptions={limeOptions} positions={polyline} /> */}
+      <ClickLayer positions={positions} setPositions={setPositions}/>
+      {Markers}
+      {polyline === [] ? null : <Polyline pathOptions={limeOptions} positions={polyline} />}
     </MapContainer>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import 'leaflet/dist/leaflet.css';
+import { nanoid } from 'nanoid';
 import { MapContainer, TileLayer, Marker, Popup, useMapEvents, Polyline, useMapEvent } from 'react-leaflet';
 import { LatLng } from 'leaflet';
 
@@ -20,7 +21,7 @@ function MarkerComponent(){
   })
 
   const Markers = positions.map((pos: LatLng) => {
-    return <Marker position={[pos.lat, pos.lng]}/>
+    return <Marker position={[pos.lat, pos.lng]} key={nanoid()}/>
   })
   
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,33 @@
-import React from 'react';
+import { useState } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import 'leaflet/dist/leaflet.css';
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMapEvents, Polyline } from 'react-leaflet';
+
+const polyline: any = [
+  [51.505, -0.09],
+  [51.51, -0.1],
+  [51.51, -0.12],
+]
+const limeOptions = { color: 'lime' }
+
+function LocationMarker(){
+  const [position, setPosition]: any = useState(null);
+  const map = useMapEvents({
+    click(){
+      map.locate() //ユーザーの現在地点を取得してlocationfoundイベントを発火させる
+    },
+    locationfound(e: any) {
+      setPosition(e.latlng)
+      map.flyTo(e.latlng, map.getZoom())
+    },
+  })
+  return position === null ? null : (
+    <Marker position={position}>
+      <Popup>You are here</Popup>
+    </Marker>
+  )
+}
 
 function App() {
   return (
@@ -16,6 +41,8 @@ function App() {
           A pretty CSS3 popup. <br /> Easily customizable.
         </Popup>
       </Marker>
+      <LocationMarker />
+      <Polyline pathOptions={limeOptions} positions={polyline} />
     </MapContainer>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import Leaflet from 'leaflet';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+
+//ここでマーカーの画像のパスを指定する(defaultはundefined); => この処理はどっか別に移したいところ
+Leaflet.Icon.Default.imagePath = '//cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/'
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
## 変更点
- `create-react-app`を使ってreactでSPA(Single Page Application)に必要なディレクトリやファイルを生成
  - webpackを使ってファイル分割したjsファイルをまとめて一つのファイルにして動くようにしてくれる <= これが大きい
  - JSXでDOMの生成を表現できるようになる
  - Reactが使うライブラリ(react, react-dom, react-scriptなど)を入れてくれる(何が何してるのかまでは把握してない)
- react-leafletを使ってマップ表示
  - reactでleafletを扱いやすくするために`react-leaflet`をインストール
  - stateなどのhooks(reactの便利なオプション機能みたいなイメージ)を使ってleafletを扱えるようにしたラッパー
- クリックでマーカーとラインを描いてみた
  - Appコンポーネントで簡単な機能を練習してみた
  - Appでpositionsというデータを持っており、地図をクリックすることでこのデータが変更される
  - positionsの地点にマーカーを起き、前後のpositions同士で線を引くように表示させている
  - リセットボタンを押すとpositonsが初期化される

## やってないこと
- コンポーネントとか細かく分ていない
- typescriptで型指定やインターフェースの指定をしていない(anyでとりあえずなんでもありになってるので実質JSのまま)
   - こんな感じで最初JavaScriptとほぼおんなじで書いて、その後に型とかインターフェースを厳密にしていくことが可能