### PR TITLE
Feature/introduce type interface

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,35 @@
 import { useState } from 'react';
-import logo from './logo.svg';
 import './App.css';
 import 'leaflet/dist/leaflet.css';
 import { nanoid } from 'nanoid';
-import { MapContainer, TileLayer, Marker, Popup, useMapEvents, Polyline, useMapEvent } from 'react-leaflet';
-import { LatLng } from 'leaflet';
+import { MapContainer, TileLayer, Marker, Polyline, useMapEvent } from 'react-leaflet';
+import { LatLng, LatLngExpression, LeafletMouseEvent } from 'leaflet';
 
 const limeOptions = { color: 'lime' }
 
-function ClickLayer({positions, setPositions}: any){
-  const map = useMapEvent('click', (e: any)=>{
-    setPositions([...positions, e.latlng]);
+type ClickLayerProps = {
+  positions: LatLng[],
+  setPositions: React.Dispatch<React.SetStateAction<LatLng[]>>
+}
+
+function ClickLayer(props: ClickLayerProps){
+  useMapEvent('click', (e: LeafletMouseEvent)=>{
+    props.setPositions([...props.positions, e.latlng]);
   })
   
   return null;
 }
 
 function App() {
-  const [positions, setPositions] = useState([]);
+  const [positions, setPositions] = useState< LatLng[]>([]);
 
-  const polyline: any = positions.map((pos: LatLng) => [pos.lat, pos.lng])
+  const polyline: LatLngExpression[] = positions.map((pos: LatLng) => [pos.lat, pos.lng])
 
   const Markers: any = positions.map((pos: LatLng) => {
     return <Marker position={[pos.lat, pos.lng]} key={nanoid()}/>
   })
 
-  function onClickHandler(){
+  function onClickHandler(): void{
     setPositions([]);
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,14 @@ import { nanoid } from 'nanoid';
 import { MapContainer, TileLayer, Marker, Polyline, useMapEvent } from 'react-leaflet';
 import { LatLng, LatLngExpression, LeafletMouseEvent } from 'leaflet';
 
-const limeOptions = { color: 'lime' }
+const limeOptions: {color: string} = { color: 'lime' }
 
 type ClickLayerProps = {
   positions: LatLng[],
   setPositions: React.Dispatch<React.SetStateAction<LatLng[]>>
 }
 
-function ClickLayer(props: ClickLayerProps){
+function ClickLayer(props: ClickLayerProps): null{
   useMapEvent('click', (e: LeafletMouseEvent)=>{
     props.setPositions([...props.positions, e.latlng]);
   })
@@ -20,12 +20,12 @@ function ClickLayer(props: ClickLayerProps){
   return null;
 }
 
-function App() {
+function App(): JSX.Element{
   const [positions, setPositions] = useState< LatLng[]>([]);
 
-  const polyline: LatLngExpression[] = positions.map((pos: LatLng) => [pos.lat, pos.lng])
+  const polyline: LatLngExpression[] = positions.map((pos: LatLng): LatLngExpression => [pos.lat, pos.lng])
 
-  const Markers: any = positions.map((pos: LatLng) => {
+  const Markers: JSX.Element[] = positions.map((pos: LatLng): JSX.Element => {
     return <Marker position={[pos.lat, pos.lng]} key={nanoid()}/>
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function ClickLayer(props: ClickLayerProps): null{
 }
 
 function App(): JSX.Element{
-  const [positions, setPositions] = useState< LatLng[]>([]);
+  const [positions, setPositions] = useState<LatLng[]>([]);
 
   const polyline: LatLngExpression[] = positions.map((pos: LatLng): LatLngExpression => [pos.lat, pos.lng])
 


### PR DESCRIPTION
## 変更点
- 変数、関数の引数戻り値について型指定をした。
- 今のreactは関数を使ってコンポーネントを書くのが主流(昔まではクラスでやっていた)で、コンポーネントの関数の引数としてprops受け取るので、そこについても型指定 (ClickLayerPropsなど)<= これが一番大事、もっと大規模になればインターフェース導入するのかな
- propsによってコンポーネント同士が依存関係にあるので、どこかでコンポーネントのpropsの型をまとめるファイルを作って、コンポーネントの中身は、そのファイルに依存させて、可読性を上げていきたい。

Closes #7 