### PR TITLE
Feature/insert eject point

### DIFF
--- a/src/api/route.ts
+++ b/src/api/route.ts
@@ -1,0 +1,91 @@
+import axios from 'axios'
+
+//axiosからのレスポンスのデータのインターフェース
+interface Response{
+    points: ResponsePoint[],
+    message: string
+}
+
+//axiosのレスポンスデータのpointの型
+type ResponsePoint = {
+    latitude: number,
+    longitude: number
+}
+
+export async function getRoute(route: string){
+    let res;
+    try {
+        res = await axios.get(`/routes/${route}`);
+    } catch (error) {
+        console.error(error)
+    }
+    return res;
+}
+
+export async function patchAdd(latitude: number, longitude: number, position: number, route: string){
+    const payload = {
+        coord:{
+            latitude: latitude,
+            longitude: longitude
+        }
+    }
+    let res;
+    try {
+        res = await axios.patch<Response>(`/routes/${route}/add/${position}`, payload);
+        return res
+    } catch (error) {
+        if(error.response.data.message){
+            console.error(error.response.data.message);
+        }
+    }
+    return res;
+}
+
+export async function patchDelete(route: string, pos: number){
+    let res;
+    try {
+        res = await axios.patch<Response>(`/routes/${route}/remove/${pos}`);
+    } catch (error) {
+        if(error.response.data.message){
+            console.error(error.response.data.message);
+        }
+    }
+    return res
+}
+
+
+export async function patchClear(route: string){
+    let res;
+    try {
+        res = await axios.patch<Response>(`/routes/${route}/clear/`);
+    } catch (error) {
+        if(error.response.data.message){
+            console.error(error.response.data.message);
+        }
+    }
+    return res;
+}
+
+export async function patchUndo(route: string){
+    let res;
+    try {
+        res = await axios.patch<Response>(`/routes/${route}/undo/`);
+    } catch (error) {
+        if(error.response.data.message){
+            console.error(error.response.data.message);
+        }
+    }
+    return res;
+}
+
+export async function patchRedo(route: string){
+    let res;
+    try {
+        res = await axios.patch<Response>(`/routes/${route}/redo/`);
+    } catch (error) {
+        if(error.response.data.message){
+            console.error(error.response.data.message);
+        }
+    }
+    return res;
+}

--- a/src/components/RouteEditor.tsx
+++ b/src/components/RouteEditor.tsx
@@ -65,8 +65,27 @@ function RouteEditor(props: any){
         }
     }, [props.route]);
 
-    const Markers: JSX.Element[] = positions.map((pos: LatLng): JSX.Element => {
-        return <Marker position={[pos.lat, pos.lng]} key={nanoid()}/>
+    const Markers: JSX.Element[] = positions.map((pos: LatLng, idx: number): JSX.Element => {
+        async function patchDelete(pos: number){
+            //Todo try/catch使わずに.catchで書き直す
+            try {
+                const res = await axios.patch<Response>(`/routes/${props.route}/remove/${pos}`);
+                setPositions(res.data.points.map((position: any) => new LatLng(position.latitude, position.longitude)));
+            } catch (error) {
+                if(error.response.data.message){
+                    console.error(error.response.data.message);
+                }
+            }
+        }
+
+        return (
+            <Marker
+                position={[pos.lat, pos.lng]}
+                key={nanoid()}
+                eventHandlers={{click: ()=>{patchDelete(idx)}}} //todo: ここの関数を一つにまとめたい
+            >
+            </Marker>
+        )
     })
 
     const polyline: LatLngExpression[] = positions.map((pos: LatLng): LatLngExpression => [pos.lat, pos.lng])

--- a/src/components/RouteEditor.tsx
+++ b/src/components/RouteEditor.tsx
@@ -7,12 +7,14 @@ import 'leaflet/dist/leaflet.css';
 
 const limeOptions: {color: string} = { color: 'lime' }
 
+//ClickLayerコンポーネントのpropsの型
 type ClickLayerProps = {
     positions: LatLng[],
     route: string,
     setPositions: React.Dispatch<React.SetStateAction<LatLng[]>>
 }
 
+//Polylineコンポーネントのpropsの型
 type PolylineProps = {
     polyline: LatLngExpression[],
     route: string,
@@ -31,6 +33,7 @@ interface Response{
     message: string
 }
 
+//Todo: 別ファイルに移動する
 async function patchAdd(latitude: number, longitude: number, position: number, route: string){
     const payload = {
         coord:{
@@ -49,7 +52,7 @@ async function patchAdd(latitude: number, longitude: number, position: number, r
     }
     return res;
 }
-  
+
 function ClickLayer(props: ClickLayerProps): null{
     useMapEvent('click', async (e: LeafletMouseEvent)=>{
         const res = await patchAdd(e.latlng.lat, e.latlng.lng, props.positions.length, props.route);
@@ -76,6 +79,7 @@ function RouteEditor(props: any): JSX.Element{
         }
     }, [props.route]);
 
+    //Todo: コンポーネントにして、別ファイルに移動
     const Markers: JSX.Element[] = positions.map((pos: LatLng, idx: number): JSX.Element => {
         async function patchDelete(pos: number){
             //Todo try/catch使わずに.catchで書き直す
@@ -101,13 +105,16 @@ function RouteEditor(props: any): JSX.Element{
         )
     })
 
+    //Todo: stateにする
     const polyline: LatLngExpression[] = positions.map((pos: LatLng): LatLngExpression => [pos.lat, pos.lng])
 
+    //Todo: 別ファイルに移動する
     const Polylines: FunctionComponent<PolylineProps> = (props: PolylineProps) => {
         if(props.polyline.length){
             let polylines: JSX.Element[] = new Array(props.polyline.length - 1);
             for(let idx = 0; idx < props.polyline.length - 1; idx++){
                 polylines[idx] = (
+                    //Todo: 線の太さを上げて、線をクリックしやすくする
                     <Polyline
                         pathOptions={limeOptions} 
                         positions={[polyline[idx], polyline[idx + 1]]}
@@ -135,6 +142,7 @@ function RouteEditor(props: any): JSX.Element{
     }
 
     function onClickClearHandler(): void{
+        //Todo: setPositionsは関数に含めずresをreturnする関数に書き直す & 別ファイルに移動
         async function patchClear(){
             //Todo try/catch使わずに.catchで書き直す
             try {
@@ -151,6 +159,7 @@ function RouteEditor(props: any): JSX.Element{
     }
 
     function onClickUndoHandler(): void{
+        //Todo: setPositionsは関数に含めずresをreturnする関数に書き直す & 別ファイルに移動
         async function patchUndo(){
             //Todo try/catch使わずに.catchで書き直す
             try {
@@ -166,6 +175,7 @@ function RouteEditor(props: any): JSX.Element{
     }
 
     function onClickRedoHandler(): void{
+        //Todo: setPositionsは関数に含めずresをreturnする関数に書き直す & 別ファイルに移動
         async function patchRedo(){
             //Todo try/catch使わずに.catchで書き直す
             try {

--- a/src/components/RouteEditor.tsx
+++ b/src/components/RouteEditor.tsx
@@ -37,15 +37,13 @@ function RouteEditor(props: any): JSX.Element{
 
     //Mapのルート変更時にルートを取得してpositionsを変更する
     useEffect(() => {       
-        let unmounted = false
-        async function func (){
+        let unmounted = false;
+        (async function(){
             const res = await getRoute(props.route)
-            // const res = await axios.get(`/routes/${props.route}`);
             if(res && !unmounted){
                 setPositions(res.data.polyline);
             }
-        }
-        func()
+        })();
         return () => {
             unmounted = true
         }

--- a/src/components/RouteEditor.tsx
+++ b/src/components/RouteEditor.tsx
@@ -38,7 +38,7 @@ function RouteEditor(props: any): JSX.Element{
     //Mapのルート変更時にルートを取得してpositionsを変更する
     useEffect(() => {       
         let unmounted = false;
-        (async function(){
+        (async () => {
             const res = await getRoute(props.route)
             if(res && !unmounted){
                 setPositions(res.data.polyline);

--- a/src/components/RouteEditor.tsx
+++ b/src/components/RouteEditor.tsx
@@ -1,15 +1,20 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, FunctionComponent } from 'react';
 import { MapContainer, TileLayer, Marker, Polyline, useMapEvent } from 'react-leaflet';
-import { LatLng, LatLngExpression, LeafletMouseEvent } from 'leaflet';
+import L, { LatLng, LatLngExpression, LeafletMouseEvent } from 'leaflet';
 import { nanoid } from 'nanoid';
 import axios from 'axios'
 import 'leaflet/dist/leaflet.css';
 
 const limeOptions: {color: string} = { color: 'lime' }
 
-//Todo: interface使うようにする
 type ClickLayerProps = {
     positions: LatLng[],
+    route: string,
+    setPositions: React.Dispatch<React.SetStateAction<LatLng[]>>
+}
+
+type PolylineProps = {
+    polyline: LatLngExpression[],
     route: string,
     setPositions: React.Dispatch<React.SetStateAction<LatLng[]>>
 }
@@ -25,31 +30,37 @@ interface Response{
     points: ResponsePoint[],
     message: string
 }
+
+async function patchAdd(latitude: number, longitude: number, position: number, route: string){
+    const payload = {
+        coord:{
+            latitude: latitude,
+            longitude: longitude
+        }
+    }
+    let res;
+    try {
+        res = await axios.patch<Response>(`/routes/${route}/add/${position}`, payload);
+        return res
+    } catch (error) {
+        if(error.response.data.message){
+            console.error(error.response.data.message);
+        }
+    }
+    return res;
+}
   
 function ClickLayer(props: ClickLayerProps): null{
-    useMapEvent('click', (e: LeafletMouseEvent)=>{
-        async function patchAdd(){
-            const payload = {
-                coord:{
-                    latitude: e.latlng.lat,
-                    longitude: e.latlng.lng
-                }
-            }
-            try {
-                const res = await axios.patch<Response>(`/routes/${props.route}/add/${props.positions.length}`, payload);
-                props.setPositions(res.data.points.map((position: ResponsePoint) => new LatLng(position.latitude, position.longitude)));
-            } catch (error) {
-                if(error.response.data.message){
-                    console.error(error.response.data.message);
-                }
-            }
+    useMapEvent('click', async (e: LeafletMouseEvent)=>{
+        const res = await patchAdd(e.latlng.lat, e.latlng.lng, props.positions.length, props.route);
+        if(res){
+            props.setPositions(res.data.points.map((position: ResponsePoint) => new LatLng(position.latitude, position.longitude)));
         }
-        patchAdd()
     })
     return null;
 }
 
-function RouteEditor(props: any){
+function RouteEditor(props: any): JSX.Element{
     const [positions, setPositions] = useState<LatLng[]>([]);
 
     //Mapのルート変更時にルートを取得してpositionsを変更する
@@ -82,13 +93,46 @@ function RouteEditor(props: any){
             <Marker
                 position={[pos.lat, pos.lng]}
                 key={nanoid()}
-                eventHandlers={{click: ()=>{patchDelete(idx)}}} //todo: ここの関数を一つにまとめたい
+                eventHandlers={{click: ()=>{
+                    patchDelete(idx)}
+                }} //todo: ここの関数を一つにまとめたい
             >
             </Marker>
         )
     })
 
     const polyline: LatLngExpression[] = positions.map((pos: LatLng): LatLngExpression => [pos.lat, pos.lng])
+
+    const Polylines: FunctionComponent<PolylineProps> = (props: PolylineProps) => {
+        if(props.polyline.length){
+            let polylines: JSX.Element[] = new Array(props.polyline.length - 1);
+            for(let idx = 0; idx < props.polyline.length - 1; idx++){
+                polylines[idx] = (
+                    <Polyline
+                        pathOptions={limeOptions} 
+                        positions={[polyline[idx], polyline[idx + 1]]}
+                        key={nanoid()}
+                        eventHandlers={{click: 
+                            async (event: L.LeafletMouseEvent)=>{
+                                L.DomEvent.stopPropagation(event) //clickLayerに対してクリックイベントを送らない
+                                const res = await patchAdd(event.latlng.lat, event.latlng.lng, idx + 1, props.route)
+                                if(res){
+                                    props.setPositions(res.data.points.map((position: ResponsePoint) => new LatLng(position.latitude, position.longitude)));
+                                }
+                            }
+                        }} 
+                    />
+                )
+            }
+            return(
+                <>
+                {polylines}
+                </>
+            )
+        }else{
+            return null
+        }
+    }
 
     function onClickClearHandler(): void{
         async function patchClear(){
@@ -140,13 +184,17 @@ function RouteEditor(props: any){
         <>
         <p>現在のルート: {props.route}</p>
         <MapContainer style={{height: '600px'}} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={true}>
-            {Markers}
-            <Polyline pathOptions={limeOptions} positions={polyline}/>
             <TileLayer
-            attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
-        <ClickLayer route={props.route} positions={positions} setPositions={setPositions}/>
+            {Markers}
+            <Polylines polyline={polyline} route={props.route} setPositions={setPositions}/>
+        <ClickLayer 
+            route={props.route}
+            positions={positions}
+            setPositions={setPositions}
+        />
         </MapContainer>
         {/* Todo undoできない時はボタンをdisabledにする */}
         <button onClick={onClickUndoHandler}>undo</button>


### PR DESCRIPTION
## 変更点
- マーカーをクリックするとその点が削除されるようになった
- ポリーライン上をクリック(clickableな幅が狭いので少々わかりづらいので後々修正)すると点がインサートされるようになった

## ハイライト
- 点の削除はマーカーにクリックイベントをくっつけて、クリックした際に`PATCH delete`のapiを叩くようにしてある
- 点の追加に少し苦戦した
  - ポリーラインにクリックイベントをくっつけることは容易にできたが、クリックすると地図(ClickLayer)に対してもクリックが発火してしまった(子のDOMで発火したイベントが親のDOMでも発火してしまう。イベントバブリングという)。そこで、`L.DomEvent.stopPropagation`というleafletが用意してくれたメソッドで、ポリーラインのコンポーネントで発火したイベントを親の地図(ClickLayer)のコンポーネントに送らないように処理した。
  - クリックした区間がポリーラインの何番目の区間であるかの情報の取得が、ポリーラインのクリックイベントには実装されていなかった。そこで、今まで一つのポリーラインを描画していたところを、区間ごとにポリーラインんを分けて描画することにし、区間のindexを割り振って対応した。
- コンポーネントや関数が増えたので、のちのissueでリファクタやファイル分割する予定

## 備考
レビューの際に使って欲しいバックエンドのコミット位置`c579eec`