### PR TITLE
Feature/display segments

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -5,7 +5,6 @@ import { Position, Route, Segment } from '../types'
 interface PatchResponse{
     waypoints: Position[],
     segments: Segment[],
-    message: string,
     elevation_gain: number
 }
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -5,7 +5,8 @@ import { Position, Route, Segment } from '../types'
 interface PatchResponse{
     waypoints: Position[],
     segments: Segment[],
-    message: string
+    message: string,
+    elevation_gain: number
 }
 
 interface RoutesResponse{

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -18,6 +18,10 @@ interface RouteRequestBody{
     coord: Position
 }
 
+interface RenameRequestBody{
+    name: string
+}
+
 export async function getRoute(routeId: string){
     let res;
     try {
@@ -111,6 +115,17 @@ export async function patchMove(routeId: string, idx: number, payload: RouteRequ
         }
     }
     return res;
+}
+
+export async function patchRename(routeId: string, payload: RenameRequestBody){
+    try {
+        let res = await axios.patch<RouteResponse>(`/routes/${routeId}/rename/`, payload);
+        return res
+    } catch (error) {
+        if(error.response.data.message){
+            console.error(error.response.data.message);
+        }
+    }
 }
 
 export async function postRoutes(name: string){

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
-import { Position, Route, Segment } from '../types'
+import { Position, Route, RouteGeometry } from '../types'
 
 //axiosからのレスポンスのデータのインターフェース
-interface PatchResponse{
-    waypoints: Position[],
-    segments: Segment[],
-    elevation_gain: number
-}
+interface PatchResponse extends RouteGeometry{}
 
 interface RoutesResponse{
     routes: Route[]

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,10 +1,10 @@
 import axios from 'axios'
-import { Position, Route } from '../types'
+import { Position, Route, Segment } from '../types'
 
 //axiosからのレスポンスのデータのインターフェース
 interface PatchResponse{
     waypoints: Position[],
-    linestring: Position[],
+    segments: Segment[],
     message: string
 }
 

--- a/src/components/EditableNameDisplay/index.tsx
+++ b/src/components/EditableNameDisplay/index.tsx
@@ -3,33 +3,33 @@ import { patchRename } from "../../api/routes";
 import { Route } from "../../types";
 
 type EditableNameDisplayProps = {
-  routeInfo: Route;
-  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
+  route: Route;
+  setRoute: React.Dispatch<React.SetStateAction<Route>>;
 };
 
 type NameInputProps = {
-  routeInfo: Route;
-  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
+  route: Route;
+  setRoute: React.Dispatch<React.SetStateAction<Route>>;
   isEditable: boolean;
   setIsEditable: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type NameDisplayProps = {
-  routeInfo: Route;
+  route: Route;
   isEditable: boolean;
   setIsEditable: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 function NameInput(props: NameInputProps) {
-  const [nameInput, setNameInput] = useState<string>(props.routeInfo.name);
+  const [nameInput, setNameInput] = useState<string>(props.route.name);
 
   async function onSubmitName() {
     props.setIsEditable(!props.isEditable);
-    const res = await patchRename(props.routeInfo.id, {
+    const res = await patchRename(props.route.id, {
       name: nameInput,
     });
     if (res) {
-      props.setRouteInfo({ ...props.routeInfo, ...res.data });
+      props.setRoute({ ...props.route, ...res.data });
     }
   }
 
@@ -53,6 +53,7 @@ function NameInput(props: NameInputProps) {
         type="button"
         value="更新"
       />
+
     </>
   );
 }
@@ -60,7 +61,7 @@ function NameInput(props: NameInputProps) {
 function NameDisplay(props: NameDisplayProps) {
   return (
     <>
-      <p style={{ display: "inline" }}>ルート名: {props.routeInfo.name}</p>
+      <p style={{ display: "inline" }}>ルート名: {props.route.name}</p>
       <input
         onClick={() => {
           props.setIsEditable(!props.isEditable);
@@ -79,14 +80,14 @@ export default function EditableNameDisplay(props: EditableNameDisplayProps) {
     <>
       {isEditable ? (
         <NameInput
-          routeInfo={props.routeInfo}
-          setRouteInfo={props.setRouteInfo}
+          route={props.route}
+          setRoute={props.setRoute}
           isEditable={isEditable}
           setIsEditable={setIsEditable}
         />
       ) : (
         <NameDisplay
-          routeInfo={props.routeInfo}
+          route={props.route}
           isEditable={isEditable}
           setIsEditable={setIsEditable}
         />

--- a/src/components/EditableNameDisplay/index.tsx
+++ b/src/components/EditableNameDisplay/index.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from "react";
+import { patchRename } from "../../api/routes";
+
+type EditableNameDisplayProps = {
+  routeName: string;
+  routeId: string;
+  setRouteName: React.Dispatch<React.SetStateAction<string>>;
+};
+
+export default function EditableNameDisplay(props: EditableNameDisplayProps) {
+  const [isEditable, setIsEditable] = useState<boolean>(false);
+  const [nameInput, setNameInput] = useState<string>(props.routeName);
+
+  useEffect(() => {
+    setNameInput(props.routeName);
+  }, [props.routeName]);
+
+  async function onSubmitName() {
+    setIsEditable(!isEditable);
+    const res = await patchRename(props.routeId, {
+      name: nameInput,
+    });
+    if (res) {
+      props.setRouteName(res.data.name);
+    }
+  }
+  return (
+    <>
+      {isEditable ? (
+        <>
+          <p style={{ display: "inline" }}>
+            ルート名:{" "}
+            <input
+              onChange={(e) => {
+                setNameInput(e.target.value);
+              }}
+              type="text"
+              value={nameInput}
+            />
+          </p>
+
+          <input
+            onClick={() => {
+              onSubmitName();
+            }}
+            type="button"
+            value="更新"
+          />
+        </>
+      ) : (
+        <>
+          <p style={{ display: "inline" }}>ルート名: {nameInput}</p>
+          <input
+            onClick={() => {
+              setIsEditable(!isEditable);
+            }}
+            type="button"
+            value="編集"
+            style={{ display: "inline" }}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/EditableNameDisplay/index.tsx
+++ b/src/components/EditableNameDisplay/index.tsx
@@ -1,27 +1,27 @@
 import { useState, useEffect } from "react";
 import { patchRename } from "../../api/routes";
+import { Route } from "../../types";
 
 type EditableNameDisplayProps = {
-  routeName: string;
-  routeId: string;
-  setRouteName: React.Dispatch<React.SetStateAction<string>>;
+  routeInfo: Route;
+  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
 };
 
 export default function EditableNameDisplay(props: EditableNameDisplayProps) {
   const [isEditable, setIsEditable] = useState<boolean>(false);
-  const [nameInput, setNameInput] = useState<string>(props.routeName);
+  const [nameInput, setNameInput] = useState<string>(props.routeInfo.name);
 
   useEffect(() => {
-    setNameInput(props.routeName);
-  }, [props.routeName]);
+    setNameInput(props.routeInfo.name);
+  }, [props.routeInfo.name]);
 
   async function onSubmitName() {
     setIsEditable(!isEditable);
-    const res = await patchRename(props.routeId, {
+    const res = await patchRename(props.routeInfo.id, {
       name: nameInput,
     });
     if (res) {
-      props.setRouteName(res.data.name);
+      props.setRouteInfo({ ...props.routeInfo, ...res.data });
     }
   }
   return (

--- a/src/components/EditableNameDisplay/index.tsx
+++ b/src/components/EditableNameDisplay/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { patchRename } from "../../api/routes";
 import { Route } from "../../types";
 
@@ -7,16 +7,24 @@ type EditableNameDisplayProps = {
   setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
 };
 
-export default function EditableNameDisplay(props: EditableNameDisplayProps) {
-  const [isEditable, setIsEditable] = useState<boolean>(false);
+type NameInputProps = {
+  routeInfo: Route;
+  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
+  isEditable: boolean;
+  setIsEditable: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+type NameDisplayProps = {
+  routeInfo: Route;
+  isEditable: boolean;
+  setIsEditable: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+function NameInput(props: NameInputProps) {
   const [nameInput, setNameInput] = useState<string>(props.routeInfo.name);
 
-  useEffect(() => {
-    setNameInput(props.routeInfo.name);
-  }, [props.routeInfo.name]);
-
   async function onSubmitName() {
-    setIsEditable(!isEditable);
+    props.setIsEditable(!props.isEditable);
     const res = await patchRename(props.routeInfo.id, {
       name: nameInput,
     });
@@ -24,41 +32,64 @@ export default function EditableNameDisplay(props: EditableNameDisplayProps) {
       props.setRouteInfo({ ...props.routeInfo, ...res.data });
     }
   }
+
+  return (
+    <>
+      <p style={{ display: "inline" }}>
+        ルート名:{" "}
+        <input
+          onChange={(e) => {
+            setNameInput(e.target.value);
+          }}
+          type="text"
+          value={nameInput}
+        />
+      </p>
+
+      <input
+        onClick={() => {
+          onSubmitName();
+        }}
+        type="button"
+        value="更新"
+      />
+    </>
+  );
+}
+
+function NameDisplay(props: NameDisplayProps) {
+  return (
+    <>
+      <p style={{ display: "inline" }}>ルート名: {props.routeInfo.name}</p>
+      <input
+        onClick={() => {
+          props.setIsEditable(!props.isEditable);
+        }}
+        type="button"
+        value="編集"
+        style={{ display: "inline" }}
+      />
+    </>
+  );
+}
+
+export default function EditableNameDisplay(props: EditableNameDisplayProps) {
+  const [isEditable, setIsEditable] = useState<boolean>(false);
   return (
     <>
       {isEditable ? (
-        <>
-          <p style={{ display: "inline" }}>
-            ルート名:{" "}
-            <input
-              onChange={(e) => {
-                setNameInput(e.target.value);
-              }}
-              type="text"
-              value={nameInput}
-            />
-          </p>
-
-          <input
-            onClick={() => {
-              onSubmitName();
-            }}
-            type="button"
-            value="更新"
-          />
-        </>
+        <NameInput
+          routeInfo={props.routeInfo}
+          setRouteInfo={props.setRouteInfo}
+          isEditable={isEditable}
+          setIsEditable={setIsEditable}
+        />
       ) : (
-        <>
-          <p style={{ display: "inline" }}>ルート名: {nameInput}</p>
-          <input
-            onClick={() => {
-              setIsEditable(!isEditable);
-            }}
-            type="button"
-            value="編集"
-            style={{ display: "inline" }}
-          />
-        </>
+        <NameDisplay
+          routeInfo={props.routeInfo}
+          isEditable={isEditable}
+          setIsEditable={setIsEditable}
+        />
       )}
     </>
   );

--- a/src/components/EditableNameDisplay/index.tsx
+++ b/src/components/EditableNameDisplay/index.tsx
@@ -33,6 +33,10 @@ function NameInput(props: NameInputProps) {
     }
   }
 
+  function onQuitEditing() {
+    props.setIsEditable(!props.isEditable);
+  }
+
   return (
     <>
       <p style={{ display: "inline" }}>
@@ -54,6 +58,13 @@ function NameInput(props: NameInputProps) {
         value="更新"
       />
 
+      <input
+        onClick={() => {
+          onQuitEditing();
+        }}
+        type="button"
+        value="キャンセル"
+      />
     </>
   );
 }

--- a/src/components/Markers/index.tsx
+++ b/src/components/Markers/index.tsx
@@ -3,60 +3,53 @@ import { Marker, useMap } from "react-leaflet";
 import { Marker as MarkerType } from "leaflet";
 import { nanoid } from "nanoid";
 import { patchDelete, patchMove } from "../../api/routes";
-import { Position, Segment } from "../../types";
+import { Position, Route } from "../../types";
 
 type MakersProps = {
-  waypoints: Position[];
-  route: string;
   changeCenterFlag: boolean;
+  routeInfo: Route;
+  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
   setChangeCenterFlag: React.Dispatch<React.SetStateAction<boolean>>;
-  setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
-  setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
-  setElevationGain: React.Dispatch<React.SetStateAction<number>>;
-}
+};
 
 export default function Markers(props: MakersProps) {
   const map = useMap();
   const markerRefs = useRef<Array<RefObject<MarkerType>>>(
-    Array(props.waypoints.length)
+    Array(props.routeInfo.waypoints.length)
   );
   useEffect(() => {
     if (props.changeCenterFlag) {
-      if (props.waypoints.length) {
+      if (props.routeInfo.waypoints.length) {
         map.setView([
-          props.waypoints[0].latitude,
-          props.waypoints[0].longitude,
+          props.routeInfo.waypoints[0].latitude,
+          props.routeInfo.waypoints[0].longitude,
         ]);
       }
       props.setChangeCenterFlag(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.changeCenterFlag]);
-  const markers = props.waypoints.map(
+  const markers = props.routeInfo.waypoints.map(
     (pos: Position, idx: number): JSX.Element => {
       markerRefs.current[idx] = createRef<MarkerType>();
       async function onClickMarker(idx: number) {
-        const res = await patchDelete(props.route, idx);
+        const res = await patchDelete(props.routeInfo.id, idx);
         if (res) {
-          props.setWaypoints(res.data.waypoints);
-          props.setSegments(res.data.segments);
-          props.setElevationGain(res.data.elevation_gain);
+          props.setRouteInfo({ ...props.routeInfo, ...res.data });
         }
       }
 
       async function onDragMarker(idx: number) {
         const newPoint = markerRefs.current[idx].current?.getLatLng();
         if (newPoint) {
-          const res = await patchMove(props.route, idx, {
+          const res = await patchMove(props.routeInfo.id, idx, {
             coord: {
               latitude: newPoint.lat,
               longitude: newPoint.lng,
             },
           });
           if (res) {
-            props.setWaypoints(res.data.waypoints);
-            props.setSegments(res.data.segments);
-            props.setElevationGain(res.data.elevation_gain);
+            props.setRouteInfo({ ...props.routeInfo, ...res.data });
           }
         }
       }

--- a/src/components/Markers/index.tsx
+++ b/src/components/Markers/index.tsx
@@ -12,7 +12,8 @@ type MakersProps = {
   setChangeCenterFlag: React.Dispatch<React.SetStateAction<boolean>>;
   setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
   setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
-};
+  setElevationGain: React.Dispatch<React.SetStateAction<number>>;
+}
 
 export default function Markers(props: MakersProps) {
   const map = useMap();
@@ -39,6 +40,7 @@ export default function Markers(props: MakersProps) {
         if (res) {
           props.setWaypoints(res.data.waypoints);
           props.setSegments(res.data.segments);
+          props.setElevationGain(res.data.elevation_gain);
         }
       }
 
@@ -54,6 +56,7 @@ export default function Markers(props: MakersProps) {
           if (res) {
             props.setWaypoints(res.data.waypoints);
             props.setSegments(res.data.segments);
+            props.setElevationGain(res.data.elevation_gain);
           }
         }
       }

--- a/src/components/Markers/index.tsx
+++ b/src/components/Markers/index.tsx
@@ -7,49 +7,49 @@ import { Position, Route } from "../../types";
 
 type MakersProps = {
   changeCenterFlag: boolean;
-  routeInfo: Route;
-  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
+  route: Route;
+  setRoute: React.Dispatch<React.SetStateAction<Route>>;
   setChangeCenterFlag: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function Markers(props: MakersProps) {
   const map = useMap();
   const markerRefs = useRef<Array<RefObject<MarkerType>>>(
-    Array(props.routeInfo.waypoints.length)
+    Array(props.route.waypoints.length)
   );
   useEffect(() => {
     if (props.changeCenterFlag) {
-      if (props.routeInfo.waypoints.length) {
+      if (props.route.waypoints.length) {
         map.setView([
-          props.routeInfo.waypoints[0].latitude,
-          props.routeInfo.waypoints[0].longitude,
+          props.route.waypoints[0].latitude,
+          props.route.waypoints[0].longitude,
         ]);
       }
       props.setChangeCenterFlag(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.changeCenterFlag]);
-  const markers = props.routeInfo.waypoints.map(
+  const markers = props.route.waypoints.map(
     (pos: Position, idx: number): JSX.Element => {
       markerRefs.current[idx] = createRef<MarkerType>();
       async function onClickMarker(idx: number) {
-        const res = await patchDelete(props.routeInfo.id, idx);
+        const res = await patchDelete(props.route.id, idx);
         if (res) {
-          props.setRouteInfo({ ...props.routeInfo, ...res.data });
+          props.setRoute({ ...props.route, ...res.data });
         }
       }
 
       async function onDragMarker(idx: number) {
         const newPoint = markerRefs.current[idx].current?.getLatLng();
         if (newPoint) {
-          const res = await patchMove(props.routeInfo.id, idx, {
+          const res = await patchMove(props.route.id, idx, {
             coord: {
               latitude: newPoint.lat,
               longitude: newPoint.lng,
             },
           });
           if (res) {
-            props.setRouteInfo({ ...props.routeInfo, ...res.data });
+            props.setRoute({ ...props.route, ...res.data });
           }
         }
       }

--- a/src/components/Markers/index.tsx
+++ b/src/components/Markers/index.tsx
@@ -3,7 +3,7 @@ import { Marker, useMap } from "react-leaflet";
 import { Marker as MarkerType } from "leaflet";
 import { nanoid } from "nanoid";
 import { patchDelete, patchMove } from "../../api/routes";
-import { Position } from "../../types";
+import { Position, Segment } from "../../types";
 
 type MakersProps = {
   waypoints: Position[];
@@ -11,7 +11,7 @@ type MakersProps = {
   changeCenterFlag: boolean;
   setChangeCenterFlag: React.Dispatch<React.SetStateAction<boolean>>;
   setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
-  setLinestring: React.Dispatch<React.SetStateAction<Position[]>>;
+  setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
 };
 
 export default function Markers(props: MakersProps) {
@@ -38,7 +38,7 @@ export default function Markers(props: MakersProps) {
         const res = await patchDelete(props.route, idx);
         if (res) {
           props.setWaypoints(res.data.waypoints);
-          props.setLinestring(res.data.linestring);
+          props.setSegments(res.data.segments);
         }
       }
 
@@ -53,7 +53,7 @@ export default function Markers(props: MakersProps) {
           });
           if (res) {
             props.setWaypoints(res.data.waypoints);
-            props.setLinestring(res.data.linestring);
+            props.setSegments(res.data.segments);
           }
         }
       }

--- a/src/components/Polylines/index.tsx
+++ b/src/components/Polylines/index.tsx
@@ -12,6 +12,7 @@ type PolylineProps = {
   route: string;
   setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
   setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
+  setElevationGain: React.Dispatch<React.SetStateAction<number>>;
 };
 
 export default function Polylines(props: PolylineProps) {
@@ -39,6 +40,7 @@ export default function Polylines(props: PolylineProps) {
               if (res) {
                 props.setWaypoints(res.data.waypoints);
                 props.setSegments(res.data.segments);
+                props.setElevationGain(res.data.elevation_gain);
               }
             },
           }}

--- a/src/components/Polylines/index.tsx
+++ b/src/components/Polylines/index.tsx
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import { patchAdd } from "../../api/routes";
 import { Position, Segment } from "../../types";
 
-const limeOptions: { color: string } = { color: "lime" };
+const blueOptions: { color: string } = { color: "#0000cd" };
 
 //Polylineコンポーネントのpropsの型
 type PolylineProps = {
@@ -22,7 +22,7 @@ export default function Polylines(props: PolylineProps) {
       polylines[idx] = (
         //Todo: 線の太さを上げて、線をクリックしやすくする
         <Polyline
-          pathOptions={limeOptions}
+          pathOptions={blueOptions}
           positions={props.segments[idx]["points"].map((point) => [
             point.latitude,
             point.longitude,

--- a/src/components/Polylines/index.tsx
+++ b/src/components/Polylines/index.tsx
@@ -13,37 +13,33 @@ type PolylineProps = {
 };
 
 export default function Polylines(props: PolylineProps) {
-  if (props.routeInfo.segments.length) {
-    let polylines: JSX.Element[] = new Array(props.routeInfo.segments.length);
-    for (let idx = 0; idx < props.routeInfo.segments.length; idx++) {
-      polylines[idx] = (
-        //Todo: 線の太さを上げて、線をクリックしやすくする
-        <Polyline
-          pathOptions={blueOptions}
-          positions={props.routeInfo.segments[idx]["points"].map((point) => [
-            point.latitude,
-            point.longitude,
-          ])}
-          key={nanoid()}
-          eventHandlers={{
-            click: async (event: L.LeafletMouseEvent) => {
-              L.DomEvent.stopPropagation(event); //clickLayerに対してクリックイベントを送らない
-              const res = await patchAdd(props.routeInfo.id, idx + 1, {
-                coord: {
-                  latitude: event.latlng.lat,
-                  longitude: event.latlng.lng,
-                },
-              });
-              if (res) {
-                props.setRouteInfo({ ...props.routeInfo, ...res.data });
-              }
-            },
-          }}
-        />
-      );
-    }
-    return <>{polylines}</>;
-  } else {
-    return null;
+  let polylines: JSX.Element[] = new Array(props.routeInfo.segments.length);
+  for (let idx = 0; idx < props.routeInfo.segments.length; idx++) {
+    polylines[idx] = (
+      //Todo: 線の太さを上げて、線をクリックしやすくする
+      <Polyline
+        pathOptions={blueOptions}
+        positions={props.routeInfo.segments[idx]["points"].map((point) => [
+          point.latitude,
+          point.longitude,
+        ])}
+        key={nanoid()}
+        eventHandlers={{
+          click: async (event: L.LeafletMouseEvent) => {
+            L.DomEvent.stopPropagation(event); //clickLayerに対してクリックイベントを送らない
+            const res = await patchAdd(props.routeInfo.id, idx + 1, {
+              coord: {
+                latitude: event.latlng.lat,
+                longitude: event.latlng.lng,
+              },
+            });
+            if (res) {
+              props.setRouteInfo({ ...props.routeInfo, ...res.data });
+            }
+          },
+        }}
+      />
+    );
   }
+  return <>{polylines}</>;
 }

--- a/src/components/Polylines/index.tsx
+++ b/src/components/Polylines/index.tsx
@@ -1,28 +1,31 @@
 import { Polyline } from "react-leaflet";
-import L, { LatLngExpression } from "leaflet";
+import L from "leaflet";
 import { nanoid } from "nanoid";
 import { patchAdd } from "../../api/routes";
-import { Position } from "../../types";
+import { Position, Segment } from "../../types";
 
 const limeOptions: { color: string } = { color: "lime" };
 
 //Polylineコンポーネントのpropsの型
 type PolylineProps = {
-  polyline: LatLngExpression[];
+  segments: Segment[];
   route: string;
   setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
-  setLinestring: React.Dispatch<React.SetStateAction<Position[]>>;
+  setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
 };
 
 export default function Polylines(props: PolylineProps) {
-  if (props.polyline.length) {
-    let polylines: JSX.Element[] = new Array(props.polyline.length - 1);
-    for (let idx = 0; idx < props.polyline.length - 1; idx++) {
+  if (props.segments.length) {
+    let polylines: JSX.Element[] = new Array(props.segments.length);
+    for (let idx = 0; idx < props.segments.length; idx++) {
       polylines[idx] = (
         //Todo: 線の太さを上げて、線をクリックしやすくする
         <Polyline
           pathOptions={limeOptions}
-          positions={[props.polyline[idx], props.polyline[idx + 1]]}
+          positions={props.segments[idx]["points"].map((point) => [
+            point.latitude,
+            point.longitude,
+          ])}
           key={nanoid()}
           eventHandlers={{
             click: async (event: L.LeafletMouseEvent) => {
@@ -35,7 +38,7 @@ export default function Polylines(props: PolylineProps) {
               });
               if (res) {
                 props.setWaypoints(res.data.waypoints);
-                props.setLinestring(res.data.linestring);
+                props.setSegments(res.data.segments);
               }
             },
           }}

--- a/src/components/Polylines/index.tsx
+++ b/src/components/Polylines/index.tsx
@@ -8,18 +8,18 @@ const blueOptions: { color: string } = { color: "#0000cd" };
 
 //Polylineコンポーネントのpropsの型
 type PolylineProps = {
-  routeInfo: Route;
-  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
+  route: Route;
+  setRoute: React.Dispatch<React.SetStateAction<Route>>;
 };
 
 export default function Polylines(props: PolylineProps) {
-  let polylines: JSX.Element[] = new Array(props.routeInfo.segments.length);
-  for (let idx = 0; idx < props.routeInfo.segments.length; idx++) {
+  let polylines: JSX.Element[] = new Array(props.route.segments.length);
+  for (let idx = 0; idx < props.route.segments.length; idx++) {
     polylines[idx] = (
       //Todo: 線の太さを上げて、線をクリックしやすくする
       <Polyline
         pathOptions={blueOptions}
-        positions={props.routeInfo.segments[idx]["points"].map((point) => [
+        positions={props.route.segments[idx]["points"].map((point) => [
           point.latitude,
           point.longitude,
         ])}
@@ -27,14 +27,14 @@ export default function Polylines(props: PolylineProps) {
         eventHandlers={{
           click: async (event: L.LeafletMouseEvent) => {
             L.DomEvent.stopPropagation(event); //clickLayerに対してクリックイベントを送らない
-            const res = await patchAdd(props.routeInfo.id, idx + 1, {
+            const res = await patchAdd(props.route.id, idx + 1, {
               coord: {
                 latitude: event.latlng.lat,
                 longitude: event.latlng.lng,
               },
             });
             if (res) {
-              props.setRouteInfo({ ...props.routeInfo, ...res.data });
+              props.setRoute({ ...props.route, ...res.data });
             }
           },
         }}

--- a/src/components/Polylines/index.tsx
+++ b/src/components/Polylines/index.tsx
@@ -2,28 +2,25 @@ import { Polyline } from "react-leaflet";
 import L from "leaflet";
 import { nanoid } from "nanoid";
 import { patchAdd } from "../../api/routes";
-import { Position, Segment } from "../../types";
+import { Route } from "../../types";
 
 const blueOptions: { color: string } = { color: "#0000cd" };
 
 //Polylineコンポーネントのpropsの型
 type PolylineProps = {
-  segments: Segment[];
-  route: string;
-  setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
-  setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
-  setElevationGain: React.Dispatch<React.SetStateAction<number>>;
+  routeInfo: Route;
+  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
 };
 
 export default function Polylines(props: PolylineProps) {
-  if (props.segments.length) {
-    let polylines: JSX.Element[] = new Array(props.segments.length);
-    for (let idx = 0; idx < props.segments.length; idx++) {
+  if (props.routeInfo.segments.length) {
+    let polylines: JSX.Element[] = new Array(props.routeInfo.segments.length);
+    for (let idx = 0; idx < props.routeInfo.segments.length; idx++) {
       polylines[idx] = (
         //Todo: 線の太さを上げて、線をクリックしやすくする
         <Polyline
           pathOptions={blueOptions}
-          positions={props.segments[idx]["points"].map((point) => [
+          positions={props.routeInfo.segments[idx]["points"].map((point) => [
             point.latitude,
             point.longitude,
           ])}
@@ -31,16 +28,14 @@ export default function Polylines(props: PolylineProps) {
           eventHandlers={{
             click: async (event: L.LeafletMouseEvent) => {
               L.DomEvent.stopPropagation(event); //clickLayerに対してクリックイベントを送らない
-              const res = await patchAdd(props.route, idx + 1, {
+              const res = await patchAdd(props.routeInfo.id, idx + 1, {
                 coord: {
                   latitude: event.latlng.lat,
                   longitude: event.latlng.lng,
                 },
               });
               if (res) {
-                props.setWaypoints(res.data.waypoints);
-                props.setSegments(res.data.segments);
-                props.setElevationGain(res.data.elevation_gain);
+                props.setRouteInfo({ ...props.routeInfo, ...res.data });
               }
             },
           }}

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -17,8 +17,8 @@ import "leaflet/dist/leaflet.css";
 
 //ClickLayerコンポーネントのpropsの型
 type ClickLayerProps = {
-  routeInfo: Route;
-  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
+  route: Route;
+  setRoute: React.Dispatch<React.SetStateAction<Route>>;
 };
 
 //URLのパラメータのinerface
@@ -28,18 +28,14 @@ interface RouteEditorParams {
 
 function ClickLayer(props: ClickLayerProps): null {
   useMapEvent("click", async (e: LeafletMouseEvent) => {
-    const res = await patchAdd(
-      props.routeInfo.id,
-      props.routeInfo.waypoints.length,
-      {
-        coord: {
-          latitude: e.latlng.lat,
-          longitude: e.latlng.lng,
-        },
-      }
-    );
+    const res = await patchAdd(props.route.id, props.route.waypoints.length, {
+      coord: {
+        latitude: e.latlng.lat,
+        longitude: e.latlng.lng,
+      },
+    });
     if (res) {
-      props.setRouteInfo({ ...props.routeInfo, ...res.data });
+      props.setRoute({ ...props.route, ...res.data });
     }
   });
   return null;
@@ -47,7 +43,7 @@ function ClickLayer(props: ClickLayerProps): null {
 
 const RouteEditor: FunctionComponent = () => {
   const { routeId } = useParams<RouteEditorParams>();
-  const [routeInfo, setRouteInfo] = useState<Route>({
+  const [route, setRoute] = useState<Route>({
     id: routeId,
     name: "",
     waypoints: [],
@@ -62,7 +58,7 @@ const RouteEditor: FunctionComponent = () => {
     (async () => {
       const res = await getRoute(routeId);
       if (res && !unmounted) {
-        setRouteInfo({ ...res.data });
+        setRoute({ ...res.data });
       }
     })();
     return () => {
@@ -73,21 +69,21 @@ const RouteEditor: FunctionComponent = () => {
   async function onClickClearHandler(): Promise<void> {
     const res = await patchClear(routeId);
     if (res) {
-      setRouteInfo({ ...routeInfo, ...res.data });
+      setRoute({ ...route, ...res.data });
     }
   }
 
   async function onClickUndoHandler(): Promise<void> {
     const res = await patchUndo(routeId);
     if (res) {
-      setRouteInfo({ ...routeInfo, ...res.data });
+      setRoute({ ...route, ...res.data });
     }
   }
 
   async function onClickRedoHandler(): Promise<void> {
     const res = await patchRedo(routeId);
     if (res) {
-      setRouteInfo({ ...routeInfo, ...res.data });
+      setRoute({ ...route, ...res.data });
     }
   }
 
@@ -97,9 +93,9 @@ const RouteEditor: FunctionComponent = () => {
       <hr />
       <p>ルートid: {routeId}</p>
 
-      <EditableNameDisplay routeInfo={routeInfo} setRouteInfo={setRouteInfo} />
+      <EditableNameDisplay route={route} setRoute={setRoute} />
 
-      <p>獲得標高: {routeInfo.elevation_gain}m</p>
+      <p>獲得標高: {route.elevation_gain}m</p>
       <MapContainer
         style={{ height: "600px" }}
         center={[35.68139740310467, 139.7671569841016]}
@@ -112,12 +108,12 @@ const RouteEditor: FunctionComponent = () => {
         />
         <Markers
           changeCenterFlag={changeCenterFlag}
-          routeInfo={routeInfo}
-          setRouteInfo={setRouteInfo}
+          route={route}
+          setRoute={setRoute}
           setChangeCenterFlag={setChangeCenterFlag}
         />
-        <Polylines routeInfo={routeInfo} setRouteInfo={setRouteInfo} />
-        <ClickLayer routeInfo={routeInfo} setRouteInfo={setRouteInfo} />
+        <Polylines route={route} setRoute={setRoute} />
+        <ClickLayer route={route} setRoute={setRoute} />
       </MapContainer>
       {/* Todo undoできない時はボタンをdisabledにする */}
       <button onClick={onClickUndoHandler}>undo</button>

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -79,6 +79,7 @@ const RouteEditor: FunctionComponent = () => {
     if (res) {
       setWaypoints(res.data.waypoints);
       setSegments(res.data.segments);
+      setElevationGain(res.data.elevation_gain || 0);
     }
   }
 
@@ -87,6 +88,7 @@ const RouteEditor: FunctionComponent = () => {
     if (res) {
       setWaypoints(res.data.waypoints);
       setSegments(res.data.segments);
+      setElevationGain(res.data.elevation_gain || 0);
     }
   }
 
@@ -95,6 +97,7 @@ const RouteEditor: FunctionComponent = () => {
     if (res) {
       setWaypoints(res.data.waypoints);
       setSegments(res.data.segments);
+      setElevationGain(res.data.elevation_gain || 0);
     }
   }
 
@@ -128,12 +131,14 @@ const RouteEditor: FunctionComponent = () => {
           setChangeCenterFlag={setChangeCenterFlag}
           setWaypoints={setWaypoints}
           setSegments={setSegments}
+          setElevationGain={setElevationGain}
         />
         <Polylines
           segments={segments}
           route={routeId}
           setWaypoints={setWaypoints}
           setSegments={setSegments}
+          setElevationGain={setElevationGain}
         />
         <ClickLayer
           route={routeId}

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FunctionComponent } from "react";
 import { useParams, Link } from "react-router-dom";
-import { MapContainer, TileLayer, Polyline, useMapEvent } from "react-leaflet";
-import { LatLngExpression, LeafletMouseEvent } from "leaflet";
+import { MapContainer, TileLayer, useMapEvent } from "react-leaflet";
+import { LeafletMouseEvent } from "leaflet";
 import {
   getRoute,
   patchAdd,
@@ -9,7 +9,7 @@ import {
   patchRedo,
   patchClear,
 } from "../../api/routes";
-import { Position } from "../../types";
+import { Position, Segment } from "../../types";
 import Markers from "../../components/Markers";
 import Polylines from "../../components/Polylines";
 import "leaflet/dist/leaflet.css";
@@ -19,7 +19,7 @@ type ClickLayerProps = {
   waypoints: Position[];
   route: string;
   setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
-  setLinestring: React.Dispatch<React.SetStateAction<Position[]>>;
+  setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
 };
 
 //URLのパラメータのinerface
@@ -37,7 +37,7 @@ function ClickLayer(props: ClickLayerProps): null {
     });
     if (res) {
       props.setWaypoints(res.data.waypoints);
-      props.setLinestring(res.data.linestring);
+      props.setSegments(res.data.segments);
     }
   });
   return null;
@@ -45,12 +45,9 @@ function ClickLayer(props: ClickLayerProps): null {
 
 const RouteEditor: FunctionComponent = () => {
   const [waypoints, setWaypoints] = useState<Position[]>([]);
-  const [linestring, setLinestring] = useState<Position[]>([]);
+  const [segments, setSegments] = useState<Segment[]>([]);
   const [routeName, setRouteName] = useState<string>("");
   const [changeCenterFlag, setChangeCenterFlag] = useState<boolean>(false);
-  const polyline = waypoints.map(
-    (pos: Position): LatLngExpression => [pos.latitude, pos.longitude]
-  );
   const { routeId } = useParams<RouteEditorParams>();
 
   //Mapのルート変更時にルートを取得してwaypointsを変更する
@@ -62,8 +59,8 @@ const RouteEditor: FunctionComponent = () => {
         if (res.data.waypoints) {
           setWaypoints(res.data.waypoints);
         }
-        if (res.data.linestring) {
-          setLinestring(res.data.linestring);
+        if (res.data.segments) {
+          setSegments(res.data.segments);
         }
         setRouteName(res.data.name);
         setChangeCenterFlag(true);
@@ -78,7 +75,7 @@ const RouteEditor: FunctionComponent = () => {
     const res = await patchClear(routeId);
     if (res) {
       setWaypoints(res.data.waypoints);
-      setLinestring(res.data.linestring);
+      setSegments(res.data.segments);
     }
   }
 
@@ -86,7 +83,7 @@ const RouteEditor: FunctionComponent = () => {
     const res = await patchUndo(routeId);
     if (res) {
       setWaypoints(res.data.waypoints);
-      setLinestring(res.data.linestring);
+      setSegments(res.data.segments);
     }
   }
 
@@ -94,7 +91,7 @@ const RouteEditor: FunctionComponent = () => {
     const res = await patchRedo(routeId);
     if (res) {
       setWaypoints(res.data.waypoints);
-      setLinestring(res.data.linestring);
+      setSegments(res.data.segments);
     }
   }
 
@@ -120,22 +117,19 @@ const RouteEditor: FunctionComponent = () => {
           changeCenterFlag={changeCenterFlag}
           setChangeCenterFlag={setChangeCenterFlag}
           setWaypoints={setWaypoints}
-          setLinestring={setLinestring}
+          setSegments={setSegments}
         />
         <Polylines
-          polyline={polyline}
+          segments={segments}
           route={routeId}
           setWaypoints={setWaypoints}
-          setLinestring={setLinestring}
-        />
-        <Polyline
-          positions={linestring.map((pos) => [pos.latitude, pos.longitude])}
+          setSegments={setSegments}
         />
         <ClickLayer
           route={routeId}
           waypoints={waypoints}
           setWaypoints={setWaypoints}
-          setLinestring={setLinestring}
+          setSegments={setSegments}
         />
       </MapContainer>
       {/* Todo undoできない時はボタンをdisabledにする */}

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -12,6 +12,7 @@ import {
 import { Position, Segment } from "../../types";
 import Markers from "../../components/Markers";
 import Polylines from "../../components/Polylines";
+import EditableNameDisplay from "../../components/EditableNameDisplay";
 import "leaflet/dist/leaflet.css";
 
 //ClickLayerコンポーネントのpropsの型
@@ -47,6 +48,7 @@ const RouteEditor: FunctionComponent = () => {
   const [waypoints, setWaypoints] = useState<Position[]>([]);
   const [segments, setSegments] = useState<Segment[]>([]);
   const [routeName, setRouteName] = useState<string>("");
+  const [elevationGain, setElevationGain] = useState<number>(0);
   const [changeCenterFlag, setChangeCenterFlag] = useState<boolean>(false);
   const { routeId } = useParams<RouteEditorParams>();
 
@@ -62,6 +64,7 @@ const RouteEditor: FunctionComponent = () => {
         if (res.data.segments) {
           setSegments(res.data.segments);
         }
+        setElevationGain(res.data.elevation_gain || 0);
         setRouteName(res.data.name);
         setChangeCenterFlag(true);
       }
@@ -100,7 +103,14 @@ const RouteEditor: FunctionComponent = () => {
       <Link to="/">ルート一覧へ</Link>
       <hr />
       <p>ルートid: {routeId}</p>
-      <p>ルート名: {routeName}</p>
+
+      <EditableNameDisplay
+        routeId={routeId}
+        setRouteName={setRouteName}
+        routeName={routeName}
+      />
+
+      <p>獲得標高: {elevationGain}m</p>
       <MapContainer
         style={{ height: "600px" }}
         center={[35.68139740310467, 139.7671569841016]}

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -21,6 +21,7 @@ type ClickLayerProps = {
   route: string;
   setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
   setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
+  setElevationGain: React.Dispatch<React.SetStateAction<number>>;
 };
 
 //URLのパラメータのinerface
@@ -39,6 +40,7 @@ function ClickLayer(props: ClickLayerProps): null {
     if (res) {
       props.setWaypoints(res.data.waypoints);
       props.setSegments(res.data.segments);
+      props.setElevationGain(res.data.elevation_gain)
     }
   });
   return null;
@@ -145,6 +147,7 @@ const RouteEditor: FunctionComponent = () => {
           waypoints={waypoints}
           setWaypoints={setWaypoints}
           setSegments={setSegments}
+          setElevationGain={setElevationGain}
         />
       </MapContainer>
       {/* Todo undoできない時はボタンをdisabledにする */}

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -9,19 +9,16 @@ import {
   patchRedo,
   patchClear,
 } from "../../api/routes";
-import { Position, Segment } from "../../types";
 import Markers from "../../components/Markers";
 import Polylines from "../../components/Polylines";
 import EditableNameDisplay from "../../components/EditableNameDisplay";
+import { Route } from "../../types";
 import "leaflet/dist/leaflet.css";
 
 //ClickLayerコンポーネントのpropsの型
 type ClickLayerProps = {
-  waypoints: Position[];
-  route: string;
-  setWaypoints: React.Dispatch<React.SetStateAction<Position[]>>;
-  setSegments: React.Dispatch<React.SetStateAction<Segment[]>>;
-  setElevationGain: React.Dispatch<React.SetStateAction<number>>;
+  routeInfo: Route;
+  setRouteInfo: React.Dispatch<React.SetStateAction<Route>>;
 };
 
 //URLのパラメータのinerface
@@ -31,28 +28,33 @@ interface RouteEditorParams {
 
 function ClickLayer(props: ClickLayerProps): null {
   useMapEvent("click", async (e: LeafletMouseEvent) => {
-    const res = await patchAdd(props.route, props.waypoints.length, {
-      coord: {
-        latitude: e.latlng.lat,
-        longitude: e.latlng.lng,
-      },
-    });
+    const res = await patchAdd(
+      props.routeInfo.id,
+      props.routeInfo.waypoints.length,
+      {
+        coord: {
+          latitude: e.latlng.lat,
+          longitude: e.latlng.lng,
+        },
+      }
+    );
     if (res) {
-      props.setWaypoints(res.data.waypoints);
-      props.setSegments(res.data.segments);
-      props.setElevationGain(res.data.elevation_gain)
+      props.setRouteInfo({ ...props.routeInfo, ...res.data });
     }
   });
   return null;
 }
 
 const RouteEditor: FunctionComponent = () => {
-  const [waypoints, setWaypoints] = useState<Position[]>([]);
-  const [segments, setSegments] = useState<Segment[]>([]);
-  const [routeName, setRouteName] = useState<string>("");
-  const [elevationGain, setElevationGain] = useState<number>(0);
-  const [changeCenterFlag, setChangeCenterFlag] = useState<boolean>(false);
   const { routeId } = useParams<RouteEditorParams>();
+  const [routeInfo, setRouteInfo] = useState<Route>({
+    id: routeId,
+    name: "",
+    waypoints: [],
+    segments: [],
+    elevation_gain: 0,
+  });
+  const [changeCenterFlag, setChangeCenterFlag] = useState<boolean>(false);
 
   //Mapのルート変更時にルートを取得してwaypointsを変更する
   useEffect(() => {
@@ -60,15 +62,7 @@ const RouteEditor: FunctionComponent = () => {
     (async () => {
       const res = await getRoute(routeId);
       if (res && !unmounted) {
-        if (res.data.waypoints) {
-          setWaypoints(res.data.waypoints);
-        }
-        if (res.data.segments) {
-          setSegments(res.data.segments);
-        }
-        setElevationGain(res.data.elevation_gain || 0);
-        setRouteName(res.data.name);
-        setChangeCenterFlag(true);
+        setRouteInfo({ ...res.data });
       }
     })();
     return () => {
@@ -79,27 +73,21 @@ const RouteEditor: FunctionComponent = () => {
   async function onClickClearHandler(): Promise<void> {
     const res = await patchClear(routeId);
     if (res) {
-      setWaypoints(res.data.waypoints);
-      setSegments(res.data.segments);
-      setElevationGain(res.data.elevation_gain || 0);
+      setRouteInfo({ ...routeInfo, ...res.data });
     }
   }
 
   async function onClickUndoHandler(): Promise<void> {
     const res = await patchUndo(routeId);
     if (res) {
-      setWaypoints(res.data.waypoints);
-      setSegments(res.data.segments);
-      setElevationGain(res.data.elevation_gain || 0);
+      setRouteInfo({ ...routeInfo, ...res.data });
     }
   }
 
   async function onClickRedoHandler(): Promise<void> {
     const res = await patchRedo(routeId);
     if (res) {
-      setWaypoints(res.data.waypoints);
-      setSegments(res.data.segments);
-      setElevationGain(res.data.elevation_gain || 0);
+      setRouteInfo({ ...routeInfo, ...res.data });
     }
   }
 
@@ -109,13 +97,9 @@ const RouteEditor: FunctionComponent = () => {
       <hr />
       <p>ルートid: {routeId}</p>
 
-      <EditableNameDisplay
-        routeId={routeId}
-        setRouteName={setRouteName}
-        routeName={routeName}
-      />
+      <EditableNameDisplay routeInfo={routeInfo} setRouteInfo={setRouteInfo} />
 
-      <p>獲得標高: {elevationGain}m</p>
+      <p>獲得標高: {routeInfo.elevation_gain}m</p>
       <MapContainer
         style={{ height: "600px" }}
         center={[35.68139740310467, 139.7671569841016]}
@@ -127,28 +111,13 @@ const RouteEditor: FunctionComponent = () => {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Markers
-          waypoints={waypoints}
-          route={routeId}
           changeCenterFlag={changeCenterFlag}
+          routeInfo={routeInfo}
+          setRouteInfo={setRouteInfo}
           setChangeCenterFlag={setChangeCenterFlag}
-          setWaypoints={setWaypoints}
-          setSegments={setSegments}
-          setElevationGain={setElevationGain}
         />
-        <Polylines
-          segments={segments}
-          route={routeId}
-          setWaypoints={setWaypoints}
-          setSegments={setSegments}
-          setElevationGain={setElevationGain}
-        />
-        <ClickLayer
-          route={routeId}
-          waypoints={waypoints}
-          setWaypoints={setWaypoints}
-          setSegments={setSegments}
-          setElevationGain={setElevationGain}
-        />
+        <Polylines routeInfo={routeInfo} setRouteInfo={setRouteInfo} />
+        <ClickLayer routeInfo={routeInfo} setRouteInfo={setRouteInfo} />
       </MapContainer>
       {/* Todo undoできない時はボタンをdisabledにする */}
       <button onClick={onClickUndoHandler}>undo</button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,8 @@ export type Position = {
 export type Route = {
     id: string,
     name: string,
-    waypoints?: Position[]
-    segments?: Segment[]
+    waypoints: Position[]
+    segments: Segment[]
     elevation_gain?: number
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@ export type Route = {
     id: string,
     name: string,
     waypoints?: Position[]
-    linestring?: Position[]
+    segments?: Segment[]
     elevation_gain?: number
+}
+
+export type Segment = {
+    points: Position[],
+    distance: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,18 @@ export type Position = {
     evelation?: number,
 }
 
-export type Route = {
+export type RouteInfo = {
     id: string,
     name: string,
-    waypoints: Position[]
-    segments: Segment[]
-    elevation_gain?: number
 }
+
+export type RouteGeometry = {
+    waypoints: Position[],
+    segments: Segment[],
+    elevation_gain: number
+}
+
+export type Route = RouteInfo & RouteGeometry
 
 export type Segment = {
     points: Position[],


### PR DESCRIPTION
## 変更点
- Segment形式でのバックエンドとのやり取りに対応(daafd4a)
  - それに伴い、補間後の点から点の追加ができるようになった。
- rename機能の追加(436321f)
  - 名前の表示の横のボタンから編集モードへ切り替える仕様
- 獲得標高の表示
  - elevation_gainを取得して表示する
- RouteEditor画面のstateのリファクタ(8410b22)
  - RouteEditorに存在していた、routeName, elevationGain, waypoints, segmentsのstateを廃止し、routeInfoというオブジェクトにまとめたstateにした。これにより、ルート情報の変更箇所をほとんどすべて書き換え(それにまつわるprops)たので、コード量が減った。
- polylineの色を変える(edae1bc)
close #25 #21 #22