### PR TITLE
Feature/atomic set state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-scripts": "4.0.3",
         "recharts": "^2.0.10",
         "typescript": "^4.2.3",
+        "use-reducer-async": "^2.0.1",
         "web-vitals": "^1.1.1"
       },
       "devDependencies": {
@@ -19803,6 +19804,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-reducer-async": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/use-reducer-async/-/use-reducer-async-2.0.1.tgz",
+      "integrity": "sha512-bO0+d658kP4vD6wahKqcsf+bl5YzJZbrQYsssxOtvLAkqsclmQcjpkp9BoRKSdIL1j3ZzszvzQ/GeXQeD1x/Rw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -37333,6 +37342,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-reducer-async": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/use-reducer-async/-/use-reducer-async-2.0.1.tgz",
+      "integrity": "sha512-bO0+d658kP4vD6wahKqcsf+bl5YzJZbrQYsssxOtvLAkqsclmQcjpkp9BoRKSdIL1j3ZzszvzQ/GeXQeD1x/Rw==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-scripts": "4.0.3",
     "recharts": "^2.0.10",
     "typescript": "^4.2.3",
+    "use-reducer-async": "^2.0.1",
     "web-vitals": "^1.1.1"
   },
   "scripts": {

--- a/src/components/EditableNameDisplay/index.tsx
+++ b/src/components/EditableNameDisplay/index.tsx
@@ -1,15 +1,18 @@
 import { useState } from "react";
-import { patchRename } from "../../api/routes";
 import { Route } from "../../types";
+import {
+  routeReducerAction,
+  routeAsyncAction,
+} from "../../reducers/routeReducer";
 
 type EditableNameDisplayProps = {
   route: Route;
-  setRoute: React.Dispatch<React.SetStateAction<Route>>;
+  dispatchRoute: React.Dispatch<routeReducerAction | routeAsyncAction>;
 };
 
 type NameInputProps = {
   route: Route;
-  setRoute: React.Dispatch<React.SetStateAction<Route>>;
+  dispatchRoute: React.Dispatch<routeReducerAction | routeAsyncAction>;
   setIsEditable: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
@@ -21,18 +24,11 @@ type NameDisplayProps = {
 function NameInput(props: NameInputProps) {
   const [nameInput, setNameInput] = useState<string>(props.route.name);
 
-  async function onSubmitName() {
+  function onSubmitName() {
     props.setIsEditable((prevState) => {
       return !prevState;
     });
-    const res = await patchRename(props.route.id, {
-      name: nameInput,
-    });
-    if (res) {
-      props.setRoute((prevState) => {
-        return { ...prevState, ...res.data };
-      });
-    }
+    props.dispatchRoute({ type: "RENAME", name: nameInput });
   }
 
   function onQuitEditing() {
@@ -98,7 +94,7 @@ export default function EditableNameDisplay(props: EditableNameDisplayProps) {
       {isEditable ? (
         <NameInput
           route={props.route}
-          setRoute={props.setRoute}
+          dispatchRoute={props.dispatchRoute}
           setIsEditable={setIsEditable}
         />
       ) : (

--- a/src/components/FocusedMarker/index.tsx
+++ b/src/components/FocusedMarker/index.tsx
@@ -3,50 +3,43 @@ import { FocusedMarkerIcon } from "./focusedMarkerIcon";
 import { Marker } from "react-leaflet";
 import L, { Marker as MarkerType } from "leaflet";
 import { Route, FocusedMarkerInfo } from "../../types";
-import { patchAdd } from "../../api/routes";
+import {
+  routeAsyncAction,
+  routeReducerAction,
+} from "../../reducers/routeReducer";
 
 type FocusedMarkerProps = {
   zoomSize: number;
   route: Route;
-  setRoute: React.Dispatch<React.SetStateAction<Route>>;
   FocusedMarkerInfo: FocusedMarkerInfo;
   setFocusedMarkerInfo: React.Dispatch<React.SetStateAction<FocusedMarkerInfo>>;
+  dispatchRoute: React.Dispatch<routeReducerAction | routeAsyncAction>;
 };
 
 export default function FocusedMarker(props: FocusedMarkerProps) {
   const markerRef = useRef<MarkerType>(null);
-  async function onClickMarker(latlng: L.LatLng, idx: number) {
-    const res = await patchAdd(props.route.id, idx, {
+  function onClickMarker(latlng: L.LatLng, idx: number) {
+    props.dispatchRoute({
+      type: "INSERT",
+      targetIdx: idx,
       coord: {
         latitude: latlng.lat,
         longitude: latlng.lng,
       },
     });
-    if (res) {
-      props.setRoute((prevState) => {
-        return { ...prevState, ...res.data };
-      });
-    }
   }
 
   async function onDragMarker() {
     const newPoint = markerRef.current?.getLatLng();
     if (newPoint && props.FocusedMarkerInfo.idx !== null) {
-      const res = await patchAdd(
-        props.route.id,
-        props.FocusedMarkerInfo.idx + 1,
-        {
-          coord: {
-            latitude: newPoint.lat,
-            longitude: newPoint.lng,
-          },
-        }
-      );
-      if (res) {
-        props.setRoute((prevState) => {
-          return { ...prevState, ...res.data };
-        });
-      }
+      props.dispatchRoute({
+        type: "INSERT",
+        targetIdx: props.FocusedMarkerInfo.idx + 1,
+        coord: {
+          latitude: newPoint.lat,
+          longitude: newPoint.lng,
+        },
+      });
     }
   }
 

--- a/src/components/Markers/index.tsx
+++ b/src/components/Markers/index.tsx
@@ -84,7 +84,7 @@ function markerGenerator(
         dragend: () => {
           onDragMarker(idx);
         },
-      }} //todo: ここの関数を一つにまとめたい
+      }} //TODO: ここの関数を一つにまとめたい
     ></Marker>
   );
 }

--- a/src/components/Markers/index.tsx
+++ b/src/components/Markers/index.tsx
@@ -2,14 +2,17 @@ import { useEffect, useRef, createRef, RefObject } from "react";
 import { Marker, useMap } from "react-leaflet";
 import { Marker as MarkerType } from "leaflet";
 import { nanoid } from "nanoid";
-import { patchDelete, patchMove } from "../../api/routes";
 import { Position, Route, FocusedMarkerInfo } from "../../types";
 import { MarkerIcon, GoalMarkerIcon, StartMarkerIcon } from "./markerIcon";
+import {
+  routeReducerAction,
+  routeAsyncAction,
+} from "../../reducers/routeReducer";
 
 type MakersProps = {
   changeCenterFlag: boolean;
   route: Route;
-  setRoute: React.Dispatch<React.SetStateAction<Route>>;
+  dispatchRoute: React.Dispatch<routeReducerAction | routeAsyncAction>;
   setFocusedMarkerInfo: React.Dispatch<React.SetStateAction<FocusedMarkerInfo>>;
   setChangeCenterFlag: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -49,28 +52,20 @@ function markerGenerator(
   const markerIcon = getMarkerIcon(idx, 0, props.route.waypoints.length - 1);
   markerRef = createRef<MarkerType>();
   async function onClickMarker(idx: number) {
-    const res = await patchDelete(props.route.id, idx);
-    if (res) {
-      props.setRoute((prevState) => {
-        return { ...prevState, ...res.data };
-      });
-    }
+    props.dispatchRoute({ type: "DELETE", targetIdx: idx });
   }
 
   async function onDragMarker(idx: number) {
     const newPoint = markerRef.current?.getLatLng();
     if (newPoint) {
-      const res = await patchMove(props.route.id, idx, {
+      props.dispatchRoute({
+        type: "MOVE",
+        targetIdx: idx,
         coord: {
           latitude: newPoint.lat,
           longitude: newPoint.lng,
         },
       });
-      if (res) {
-        props.setRoute((prevState) => {
-          return { ...prevState, ...res.data };
-        });
-      }
     }
   }
 

--- a/src/components/Polylines/index.tsx
+++ b/src/components/Polylines/index.tsx
@@ -13,7 +13,6 @@ type PolylineProps = {
   setFocusedMarkerInfo: React.Dispatch<React.SetStateAction<FocusedMarkerInfo>>;
   setZoomSize: React.Dispatch<React.SetStateAction<number>>;
   route: Route;
-  setRoute: React.Dispatch<React.SetStateAction<Route>>;
 };
 
 /**

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -2,25 +2,24 @@ import { useState, useEffect, FunctionComponent } from "react";
 import { useParams, Link } from "react-router-dom";
 import { MapContainer, TileLayer, useMapEvent } from "react-leaflet";
 import { LatLng, LeafletMouseEvent } from "leaflet";
-import {
-  getRoute,
-  patchAdd,
-  patchUndo,
-  patchRedo,
-  patchClear,
-} from "../../api/routes";
+import { useReducerAsync } from "use-reducer-async";
 import Markers from "../../components/Markers";
 import Polylines from "../../components/Polylines";
 import EditableNameDisplay from "../../components/EditableNameDisplay";
 import ElevationGraph from "../../components/ElevationGraph";
 import FocusedMarker from "../../components/FocusedMarker";
-import { Route, FocusedMarkerInfo } from "../../types";
+import { FocusedMarkerInfo } from "../../types";
+import {
+  routeReducer,
+  routeAsyncActionHandlers,
+  routeReducerAction,
+  routeAsyncAction,
+} from "../../reducers/routeReducer";
 import "leaflet/dist/leaflet.css";
 
 //ClickLayerコンポーネントのpropsの型
 type ClickLayerProps = {
-  route: Route;
-  setRoute: React.Dispatch<React.SetStateAction<Route>>;
+  dispatchRoute: React.Dispatch<routeReducerAction | routeAsyncAction>;
 };
 
 //URLのパラメータのinerface
@@ -36,30 +35,30 @@ const focusedMarkerInfoInitValue: FocusedMarkerInfo = {
 
 function ClickLayer(props: ClickLayerProps): null {
   useMapEvent("click", async (e: LeafletMouseEvent) => {
-    const res = await patchAdd(props.route.id, props.route.waypoints.length, {
+    props.dispatchRoute({
+      type: "APPEND",
       coord: {
         latitude: e.latlng.lat,
         longitude: e.latlng.lng,
       },
     });
-    if (res) {
-      props.setRoute((prevState) => {
-        return { ...prevState, ...res.data };
-      });
-    }
   });
   return null;
 }
 
 const RouteEditor: FunctionComponent = () => {
   const { routeId } = useParams<RouteEditorParams>();
-  const [route, setRoute] = useState<Route>({
-    id: routeId,
-    name: "",
-    waypoints: [],
-    segments: [],
-    elevation_gain: 0,
-  });
+  const [route, dispatchRoute] = useReducerAsync(
+    routeReducer,
+    {
+      id: routeId,
+      name: "",
+      waypoints: [],
+      segments: [],
+      elevation_gain: 0,
+    },
+    routeAsyncActionHandlers
+  );
   const [changeCenterFlag, setChangeCenterFlag] = useState<boolean>(false);
   const [zoomSize, setZoomSize] = useState<number>(13);
   const [FocusedMarkerInfo, setFocusedMarkerInfo] = useState<FocusedMarkerInfo>(
@@ -72,43 +71,20 @@ const RouteEditor: FunctionComponent = () => {
 
   //Mapのルート変更時にルートを取得してwaypointsを変更する
   useEffect(() => {
-    let unmounted = false;
-    (async () => {
-      const res = await getRoute(routeId);
-      if (res && !unmounted) {
-        setRoute({ ...res.data });
-      }
-    })();
-    return () => {
-      unmounted = true;
-    };
+    dispatchRoute({ type: "GET", id: routeId });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeId]);
 
-  async function onClickClearHandler(): Promise<void> {
-    const res = await patchClear(routeId);
-    if (res) {
-      setRoute((prevState) => {
-        return { ...prevState, ...res.data };
-      });
-    }
+  function onClickClearHandler() {
+    dispatchRoute({ type: "CLEAR", id: routeId });
   }
 
-  async function onClickUndoHandler(): Promise<void> {
-    const res = await patchUndo(routeId);
-    if (res) {
-      setRoute((prevState) => {
-        return { ...prevState, ...res.data };
-      });
-    }
+  function onClickUndoHandler() {
+    dispatchRoute({ type: "UNDO", id: routeId });
   }
 
-  async function onClickRedoHandler(): Promise<void> {
-    const res = await patchRedo(routeId);
-    if (res) {
-      setRoute((prevState) => {
-        return { ...prevState, ...res.data };
-      });
-    }
+  function onClickRedoHandler() {
+    dispatchRoute({ type: "REDO", id: routeId });
   }
 
   return (
@@ -117,7 +93,7 @@ const RouteEditor: FunctionComponent = () => {
       <hr />
       <p>ルートid: {routeId}</p>
 
-      <EditableNameDisplay route={route} setRoute={setRoute} />
+      <EditableNameDisplay route={route} dispatchRoute={dispatchRoute} />
 
       <p>獲得標高: {route.elevation_gain}m</p>
       <MapContainer
@@ -133,7 +109,7 @@ const RouteEditor: FunctionComponent = () => {
         <Markers
           changeCenterFlag={changeCenterFlag}
           route={route}
-          setRoute={setRoute}
+          dispatchRoute={dispatchRoute}
           setChangeCenterFlag={setChangeCenterFlag}
           setFocusedMarkerInfo={setFocusedMarkerInfo}
         />
@@ -141,16 +117,15 @@ const RouteEditor: FunctionComponent = () => {
           setZoomSize={setZoomSize}
           setFocusedMarkerInfo={setFocusedMarkerInfo}
           route={route}
-          setRoute={setRoute}
         />
         <FocusedMarker
           zoomSize={zoomSize}
           route={route}
-          setRoute={setRoute}
+          dispatchRoute={dispatchRoute}
           FocusedMarkerInfo={FocusedMarkerInfo}
           setFocusedMarkerInfo={setFocusedMarkerInfo}
         />
-        <ClickLayer route={route} setRoute={setRoute} />
+        <ClickLayer dispatchRoute={dispatchRoute} />
       </MapContainer>
       {/* Todo undoできない時はボタンをdisabledにする */}
       <button onClick={onClickUndoHandler}>undo</button>

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -127,9 +127,9 @@ const RouteEditor: FunctionComponent = () => {
         />
         <ClickLayer dispatchRoute={dispatchRoute} />
       </MapContainer>
-      {/* Todo undoできない時はボタンをdisabledにする */}
+      {/* TODO undoできない時はボタンをdisabledにする */}
       <button onClick={onClickUndoHandler}>undo</button>
-      {/* Todo redoできない時はボタンをdisabledにする */}
+      {/* TODO redoできない時はボタンをdisabledにする */}
       <button onClick={onClickRedoHandler}>redo</button>
       <button onClick={onClickClearHandler}>clear</button>
       <ElevationGraph

--- a/src/reducers/routeReducer.ts
+++ b/src/reducers/routeReducer.ts
@@ -1,0 +1,126 @@
+import { Reducer } from "react";
+import { AsyncActionHandlers } from "use-reducer-async";
+import { Route, RouteGeometry, Position } from "../types";
+import {
+  getRoute,
+  patchAdd,
+  patchClear,
+  patchDelete,
+  patchMove,
+  patchRedo,
+  patchRename,
+  patchUndo,
+} from "../api/routes";
+
+export interface routeAsyncAction {
+  type: string;
+  id?: string;
+  coord?: Position;
+  name?: string;
+  targetIdx?: number;
+}
+
+export interface routeReducerAction {
+  type: "UPDATE_ROUTE" | "UPDATE_ROUTE_GEOMETRY";
+  newGeometry?: RouteGeometry;
+  route?: Route;
+}
+
+export const routeReducer: Reducer<Route, routeReducerAction> = (
+  route,
+  action
+) => {
+  switch (action.type) {
+    case "UPDATE_ROUTE":
+      return { ...route, ...action.route };
+    case "UPDATE_ROUTE_GEOMETRY":
+      return { ...route, ...action.newGeometry };
+    default:
+      return route;
+  }
+};
+
+export const routeAsyncActionHandlers: AsyncActionHandlers<
+  Reducer<Route, routeReducerAction>,
+  routeAsyncAction
+> = {
+  APPEND: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res =
+        action.coord &&
+        (await patchAdd(route.id, route.waypoints.length, {
+          coord: action.coord,
+        }));
+      res && dispatch({ type: "UPDATE_ROUTE_GEOMETRY", newGeometry: res.data });
+    };
+  },
+  INSERT: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res =
+        action.targetIdx !== undefined &&
+        action.coord &&
+        (await patchAdd(route.id, action.targetIdx, {
+          coord: action.coord,
+        }));
+      res && dispatch({ type: "UPDATE_ROUTE_GEOMETRY", newGeometry: res.data });
+    };
+  },
+  GET: ({ dispatch }) => {
+    return async (action) => {
+      const res = action.id && (await getRoute(action.id));
+      res && dispatch({ type: "UPDATE_ROUTE", route: res.data });
+    };
+  },
+  CLEAR: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res = await patchClear(route.id);
+      res && dispatch({ type: "UPDATE_ROUTE_GEOMETRY", newGeometry: res.data });
+    };
+  },
+  UNDO: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res = await patchUndo(route.id);
+      res && dispatch({ type: "UPDATE_ROUTE_GEOMETRY", newGeometry: res.data });
+    };
+  },
+  REDO: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res = await patchRedo(route.id);
+      res && dispatch({ type: "UPDATE_ROUTE_GEOMETRY", newGeometry: res.data });
+    };
+  },
+  RENAME: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res =
+        action.name && (await patchRename(route.id, { name: action.name }));
+      res && dispatch({ type: "UPDATE_ROUTE", route: res.data });
+    };
+  },
+  MOVE: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res =
+        action.targetIdx !== undefined &&
+        action.coord &&
+        (await patchMove(route.id, action.targetIdx, {
+          coord: action.coord,
+        }));
+      res && dispatch({ type: "UPDATE_ROUTE_GEOMETRY", newGeometry: res.data });
+    };
+  },
+  DELETE: ({ dispatch, getState }) => {
+    return async (action) => {
+      const route = getState();
+      const res =
+        action.targetIdx !== undefined &&
+        (await patchDelete(route.id, action.targetIdx));
+      res && dispatch({ type: "UPDATE_ROUTE_GEOMETRY", newGeometry: res.data });
+    };
+  },
+};

--- a/src/reducers/routeReducer.ts
+++ b/src/reducers/routeReducer.ts
@@ -12,6 +12,7 @@ import {
   patchUndo,
 } from "../api/routes";
 
+//TODO: typeをenumで指定できるようにしたい
 export interface routeAsyncAction {
   type: string;
   id?: string;


### PR DESCRIPTION
## 変更内容
このプルリクで取り組んだのは#34 のみで、use-reducer-asyncというライブラリを用いて、stateのset関数の中でasyncの処理を使ってstateの変更をprevStateを使ってatomicにできるようにした。  
ただ、この変更の中で、routeというstateについてuseStateではなくuseReducerを使って管理するようになったため、変更箇所が増えた。useReducerはset関数が多くなったstateについてstateのロジックをより簡潔に記述するためにreactから用意された機能で、use-reducer-asyncはこのuseReducerをラップしたライブラリという位置づけ。  
https://reactjs.org/docs/hooks-reference.html#usereducer

## 変更箇所
- `src/reducers/routeReducer.ts` reducersというフォルダを作りここに、reducerで管理するstateごとにファイルで管理する運用。このファイルでは今回追加されたrouteに関する変更の処理を記述している。ここではreducerを定義するだけでなく、`use-reducer-async`で使われる非同期でのreducerの処理も記述している。
- `src/pages/RouteEditor/index.tsx`では、上で定義したreducerを実際に使っている。`use-reducer-async`を使って、dispatch関数とstateを用意して、stateを参照するなり、dispatch関数を呼び出して、stateを変更するなり、propsで子コンポーネントに渡すなりをしている。
```
const [route, dispatchRoute] = useReducerAsync(
  routeReducer,
  {
    id: routeId,
    name: "",
    waypoints: [],
    segments: [],
    elevation_gain: 0,
  },
  routeAsyncActionHandlers
);
```
close #34 