### PR TITLE
Safariで地図のクリックが複数回判定される問題の解消

### DIFF
--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -116,6 +116,7 @@ const RouteEditor: FunctionComponent = () => {
           center={[35.68139740310467, 139.7671569841016]}
           zoom={13}
           scrollWheelZoom={true}
+          tap={false}
         >
           <LocateController />
           <TileLayer

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -116,6 +116,8 @@ const RouteEditor: FunctionComponent = () => {
           center={[35.68139740310467, 139.7671569841016]}
           zoom={13}
           scrollWheelZoom={true}
+          // tapをfalseにしないと、safariでクリックの挙動がおかしくなる
+          // 参考：https://github.com/Leaflet/Leaflet/issues/7255
           tap={false}
         >
           <LocateController />


### PR DESCRIPTION
Leafletのバグのようで、`MapContainer`の`tap`をfalseにすると治るとのことで、やってみたら治ったっぽい
参考： https://github.com/Leaflet/Leaflet/issues/7255

この`tap`がfalseでいいのか含め、レビューよろ
ちなみに、iOSのSafariとChromeは、この変更後も普通にタッチ操作できた
tapに関するLeafletの説明：https://leafletjs.com/reference-1.7.1.html#map-tap