### PR TITLE
Feature/loading circle control

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -58,7 +58,11 @@ export async function patchAdd(
     );
     return res;
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -77,7 +81,11 @@ export async function patchRemove(
       payload
     );
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -89,7 +97,11 @@ export async function patchClear(routeId: string) {
   try {
     res = await axios.patch<PatchResponse>(`/routes/${routeId}/clear/`);
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -101,7 +113,11 @@ export async function patchUndo(routeId: string) {
   try {
     res = await axios.patch<PatchResponse>(`/routes/${routeId}/undo/`);
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -113,7 +129,11 @@ export async function patchRedo(routeId: string) {
   try {
     res = await axios.patch<PatchResponse>(`/routes/${routeId}/redo/`);
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -133,7 +153,11 @@ export async function patchMove(
     );
     return res;
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -148,7 +172,11 @@ export async function patchRename(routeId: string, payload: RenameRequest) {
     );
     return res;
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -160,7 +188,11 @@ export async function postRoutes(name: string) {
       name: name,
     });
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }
@@ -170,7 +202,11 @@ export async function deleteRoute(id: string) {
   try {
     await axios.delete(`/routes/${id}`);
   } catch (error) {
-    if (error.response.data.message) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response &&
+      error.response.data.message
+    ) {
       console.error(error.response.data.message);
     }
   }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -40,7 +40,9 @@ export async function getRoute(routeId: string) {
   try {
     res = await axios.get<RouteResponse>(`/routes/${routeId}`);
   } catch (error) {
-    console.error(error);
+    if (hasAxiosResponseMessage(error)) {
+      console.error(error.response.data.message);
+    }
   }
   return res;
 }
@@ -50,7 +52,9 @@ export async function getRoutes() {
   try {
     res = await axios.get<RoutesResponse>("/routes/");
   } catch (error) {
-    console.error(error);
+    if (hasAxiosResponseMessage(error)) {
+      console.error(error.response.data.message);
+    }
   }
   return res;
 }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,33 +1,33 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 import { Route, RouteGeometry, Coorinate, DrawingMode } from "../types";
 
 //axiosからのレスポンスのデータのインターフェース
-interface PatchResponse extends RouteGeometry {}
+interface PatchResponseBody extends RouteGeometry {}
 
-interface RoutesResponse {
+interface RoutesResponseBody {
   routes: Route[];
 }
 
-interface RouteResponse extends Route {}
+interface RouteResponseBody extends Route {}
 
-interface RouteAddRequest {
+interface RouteAddRequestBody {
   coord: Coorinate;
   mode: DrawingMode;
 }
 
-interface RouteMoveRequest extends RouteAddRequest {}
+interface RouteMoveRequestBody extends RouteAddRequestBody {}
 
-interface RouteRemoveRequest {
+interface RouteRemoveRequestBody {
   mode: DrawingMode;
 }
 
-interface RenameRequest {
+interface RenameRequestBody {
   name: string;
 }
 
 function hasAxiosResponseMessage(
   error: unknown
-): error is { response: { data: { message: string } } } {
+): error is { response: AxiosResponse<{ message: string }> } {
   return axios.isAxiosError(error) &&
     error.response &&
     error.response.data.message
@@ -38,7 +38,7 @@ function hasAxiosResponseMessage(
 export async function getRoute(routeId: string) {
   let res;
   try {
-    res = await axios.get<RouteResponse>(`/routes/${routeId}`);
+    res = await axios.get<RouteResponseBody>(`/routes/${routeId}`);
   } catch (error) {
     if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
@@ -50,7 +50,7 @@ export async function getRoute(routeId: string) {
 export async function getRoutes() {
   let res;
   try {
-    res = await axios.get<RoutesResponse>("/routes/");
+    res = await axios.get<RoutesResponseBody>("/routes/");
   } catch (error) {
     if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
@@ -62,11 +62,11 @@ export async function getRoutes() {
 export async function patchAdd(
   routeId: string,
   idx: number,
-  payload: RouteAddRequest
+  payload: RouteAddRequestBody
 ) {
   let res;
   try {
-    res = await axios.patch<PatchResponse>(
+    res = await axios.patch<PatchResponseBody>(
       `/routes/${routeId}/add/${idx}`,
       payload
     );
@@ -82,11 +82,11 @@ export async function patchAdd(
 export async function patchRemove(
   routeId: string,
   pos: number,
-  payload: RouteRemoveRequest
+  payload: RouteRemoveRequestBody
 ) {
   let res;
   try {
-    res = await axios.patch<PatchResponse>(
+    res = await axios.patch<PatchResponseBody>(
       `/routes/${routeId}/remove/${pos}`,
       payload
     );
@@ -101,7 +101,7 @@ export async function patchRemove(
 export async function patchClear(routeId: string) {
   let res;
   try {
-    res = await axios.patch<PatchResponse>(`/routes/${routeId}/clear/`);
+    res = await axios.patch<PatchResponseBody>(`/routes/${routeId}/clear/`);
   } catch (error) {
     if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
@@ -113,7 +113,7 @@ export async function patchClear(routeId: string) {
 export async function patchUndo(routeId: string) {
   let res;
   try {
-    res = await axios.patch<PatchResponse>(`/routes/${routeId}/undo/`);
+    res = await axios.patch<PatchResponseBody>(`/routes/${routeId}/undo/`);
   } catch (error) {
     if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
@@ -125,7 +125,7 @@ export async function patchUndo(routeId: string) {
 export async function patchRedo(routeId: string) {
   let res;
   try {
-    res = await axios.patch<PatchResponse>(`/routes/${routeId}/redo/`);
+    res = await axios.patch<PatchResponseBody>(`/routes/${routeId}/redo/`);
   } catch (error) {
     if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
@@ -137,11 +137,11 @@ export async function patchRedo(routeId: string) {
 export async function patchMove(
   routeId: string,
   idx: number,
-  payload: RouteMoveRequest
+  payload: RouteMoveRequestBody
 ) {
   let res;
   try {
-    res = await axios.patch<PatchResponse>(
+    res = await axios.patch<PatchResponseBody>(
       `/routes/${routeId}/move/${idx}`,
       payload
     );
@@ -154,9 +154,9 @@ export async function patchMove(
   return res;
 }
 
-export async function patchRename(routeId: string, payload: RenameRequest) {
+export async function patchRename(routeId: string, payload: RenameRequestBody) {
   try {
-    let res = await axios.patch<RouteResponse>(
+    let res = await axios.patch<RouteResponseBody>(
       `/routes/${routeId}/rename/`,
       payload
     );

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -25,6 +25,16 @@ interface RenameRequest {
   name: string;
 }
 
+function hasAxiosResponseMessage(
+  error: unknown
+): error is { response: { data: { message: string } } } {
+  return axios.isAxiosError(error) &&
+    error.response &&
+    error.response.data.message
+    ? true
+    : false;
+}
+
 export async function getRoute(routeId: string) {
   let res;
   try {
@@ -58,11 +68,7 @@ export async function patchAdd(
     );
     return res;
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -81,11 +87,7 @@ export async function patchRemove(
       payload
     );
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -97,11 +99,7 @@ export async function patchClear(routeId: string) {
   try {
     res = await axios.patch<PatchResponse>(`/routes/${routeId}/clear/`);
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -113,11 +111,7 @@ export async function patchUndo(routeId: string) {
   try {
     res = await axios.patch<PatchResponse>(`/routes/${routeId}/undo/`);
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -129,11 +123,7 @@ export async function patchRedo(routeId: string) {
   try {
     res = await axios.patch<PatchResponse>(`/routes/${routeId}/redo/`);
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -153,11 +143,7 @@ export async function patchMove(
     );
     return res;
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -172,11 +158,7 @@ export async function patchRename(routeId: string, payload: RenameRequest) {
     );
     return res;
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -188,11 +170,7 @@ export async function postRoutes(name: string) {
       name: name,
     });
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }
@@ -202,11 +180,7 @@ export async function deleteRoute(id: string) {
   try {
     await axios.delete(`/routes/${id}`);
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      error.response &&
-      error.response.data.message
-    ) {
+    if (hasAxiosResponseMessage(error)) {
       console.error(error.response.data.message);
     }
   }

--- a/src/components/ElevationGraph/index.tsx
+++ b/src/components/ElevationGraph/index.tsx
@@ -129,12 +129,8 @@ export default function ElevationGraph(props: ElevationGraphProp) {
             type="monotone"
             dataKey="elevation"
             stroke="#8884d8"
-            // activeDot={<ElevationGraphDot/>}
             activeDot={{
               r: 8,
-              onChangeCapture: (event) => {
-                console.log(event);
-              },
             }}
           />
         </LineChart>

--- a/src/components/RouteEditController/index.tsx
+++ b/src/components/RouteEditController/index.tsx
@@ -40,7 +40,6 @@ function RouteEditControllerDisplay(props: RouteEditControllerProps) {
     approval && props.setIsLoading(true);
     props.dispatchRoute({
       type: "CLEAR",
-      id: props.routeId,
     });
   };
 
@@ -48,7 +47,6 @@ function RouteEditControllerDisplay(props: RouteEditControllerProps) {
     props.setIsLoading(true);
     props.dispatchRoute({
       type: "UNDO",
-      id: props.routeId,
     });
   };
 
@@ -56,7 +54,6 @@ function RouteEditControllerDisplay(props: RouteEditControllerProps) {
     props.setIsLoading(true);
     props.dispatchRoute({
       type: "REDO",
-      id: props.routeId,
     });
   };
 

--- a/src/components/RouteEditController/index.tsx
+++ b/src/components/RouteEditController/index.tsx
@@ -37,10 +37,12 @@ function RouteEditControllerDisplay(props: RouteEditControllerProps) {
     const approval = window.confirm(
       "経路をクリアします。(クリアの取り消しはできません)\nよろしいですか？"
     );
-    approval && props.setIsLoading(true);
-    props.dispatchRoute({
-      type: "CLEAR",
-    });
+    if (approval) {
+      props.setIsLoading(true);
+      props.dispatchRoute({
+        type: "CLEAR",
+      });
+    }
   };
 
   const onClickUndoHandler = () => {

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -146,7 +146,9 @@ const RouteEditor: FunctionComponent = () => {
           >
             {/* FIXME: opacityがCircularProgressなどにも適用されてしまう */}
             <CircularProgress />
-            <p style={{ fontWeight: "bold" }}>ルート計算中</p>
+            <p style={{ fontWeight: "bold" }}>
+              {route.isLoaded ? "ルート計算中" : "ルート取得中"}
+            </p>
           </div>
         )}
         <MapContainer

--- a/src/pages/RouteEditor/index.tsx
+++ b/src/pages/RouteEditor/index.tsx
@@ -109,6 +109,9 @@ const RouteEditor: FunctionComponent = () => {
     setFocusedMarkerInfo(focusedMarkerInfoInitValue);
     //routeに変更が見られたらrouteのローディングが完了したものとし、isLoadingをfalseにする
     setIsLoading(false);
+    if (route.error) {
+      alert(route.error.message);
+    }
   }, [route]);
 
   //Mapのルート変更時にルートを取得してwaypointsを変更する

--- a/src/reducers/routeReducer.ts
+++ b/src/reducers/routeReducer.ts
@@ -102,7 +102,7 @@ export const routeAsyncActionHandlers: AsyncActionHandlers<
       } else {
         dispatch({
           type: "ERROR",
-          errorMsg: "地点の追加に失敗しました。",
+          errorMsg: "点の追加に失敗しました。",
         });
       }
     };
@@ -122,7 +122,7 @@ export const routeAsyncActionHandlers: AsyncActionHandlers<
       } else {
         dispatch({
           type: "ERROR",
-          errorMsg: "地点の挿入に失敗しました。",
+          errorMsg: "点の挿入に失敗しました。",
         });
       }
     };
@@ -223,7 +223,7 @@ export const routeAsyncActionHandlers: AsyncActionHandlers<
       } else {
         dispatch({
           type: "ERROR",
-          errorMsg: "地点の変更に失敗しました。",
+          errorMsg: "点の変更操作に失敗しました。",
         });
       }
     };
@@ -242,7 +242,7 @@ export const routeAsyncActionHandlers: AsyncActionHandlers<
       } else {
         dispatch({
           type: "ERROR",
-          errorMsg: "地点の削除に失敗しました。",
+          errorMsg: "点の削除に失敗しました。",
         });
       }
     };

--- a/src/reducers/routeReducer.ts
+++ b/src/reducers/routeReducer.ts
@@ -84,7 +84,7 @@ export const routeReducer: Reducer<
 };
 
 export const routeAsyncActionHandlers: AsyncActionHandlers<
-  Reducer<Route & { error?: Error }, routeReducerAction>,
+  Reducer<Route, routeReducerAction>,
   routeAsyncAction
 > = {
   APPEND: ({ dispatch, getState }) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type RouteGeometry = {
   total_distance: number;
 };
 
-export type Route = RouteInfo & RouteGeometry;
+export type Route = RouteInfo & RouteGeometry & { error?: Error };
 
 export type Segment = {
   points: RoutePoint[];


### PR DESCRIPTION
## 変更点
- api呼び出し部分のtrycatchのリファクタ(57417b2)
  - catch(errror)の引数はどんな例外も扱うのでunknown型となっているため、`console.error(error.response.data.message);`と表示させるために、型チェックの処理を事前に含める修正を加えた。
    - 今回はaxiosのエラーしか扱わないため、axiosが用意してくれた`axios.isAxiosError(error)`というメソッドを使って解決した。
    close #60 
- 拾ったエラーに応じてユーザーにエラーメッセージを表示する機能の追加(e8af2af)
  - routeステートにerror?というプロパティを追加して、エラーが起きた際にはこのフィールをを使って、ユーザーにメッセージを表示させることにした。
  - 初め`trycatch`で実装することを試みたが、うまくcatchができなかった(これはおそらく非同期を無理やり同期処理にしていることが原因)のでこのような実装になった。
  - これによって、メッセージ表示の際にローディングのフラグも解除するので無限にくるくるすることはなくなった。  
  close #61 
- routeについてのreducerの型定義のリファクタ(厳密化)(c06844a)
  - 以前諦めていた`routeAsyncAction`の型定義をちゃんとした。
  close #47 
- 初回ローディング時の「ルート取得中 not ルート計算中」表示の実装(a3ec234)
  - `route.isLoaded`という初回読み込みが完了済みかのプロパティを実装済みだったのでこれを用いて簡単に実装できた。
  close #57 
- clearの入力を行う際のconfirmが正常に効いていないバグを修正した。(b652d82)
  - confirmの入力結果の評価とclearの呼び出しが関連づけられていない初歩的なミスだったので、これを修正した。